### PR TITLE
Add default recipe.view_count, remove recipe.uk1_recipe

### DIFF
--- a/schema/14.do.remove-recipe-constraint.sql
+++ b/schema/14.do.remove-recipe-constraint.sql
@@ -1,0 +1,3 @@
+alter table recipe
+  drop constraint uk1_recipe,
+  alter view_count set default 0;

--- a/schema/14.undo.remove-recipe-constraint.sql
+++ b/schema/14.undo.remove-recipe-constraint.sql
@@ -1,0 +1,3 @@
+alter table recipe
+  add constraint uk1_recipe unique (creator_id, name),
+  alter view_count drop default;


### PR DESCRIPTION
This PR removes the `uk1_recipe` key from the recipe table, which prevents users from have multiple recipes with the same name. This will break recipe versioning so it needs to go.

Also, add a default view_count of 0 for the recipe table.