### PR TITLE
Recipe persistence

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10534,6 +10534,16 @@
         }
       }
     },
+    "superagent-use": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/superagent-use/-/superagent-use-0.1.0.tgz",
+      "integrity": "sha1-0o27v1c7qYAym0ZFiXYIvJlQHP8=",
+      "dev": true,
+      "requires": {
+        "extend": "^3.0.0",
+        "methods": "~1.1.2"
+      }
+    },
     "supertest": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/supertest/-/supertest-4.0.2.tgz",
@@ -10543,6 +10553,12 @@
         "methods": "^1.1.2",
         "superagent": "^3.8.3"
       }
+    },
+    "supertest-capture-error": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supertest-capture-error/-/supertest-capture-error-1.0.0.tgz",
+      "integrity": "sha512-/W7u/L8JbGkdP+BD+pq5FDnCoOCsW1+cYEtkDzmJUafgsTr5tJ4YpVCoQQUR3njYLkGA8HfhHFr0W/S6CP+PYg==",
+      "dev": true
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1175,6 +1175,25 @@
         "@babel/types": "^7.3.0"
       }
     },
+    "@types/body-parser": {
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
+      "dev": true,
+      "requires": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/connect": {
+      "version": "3.4.32",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.32.tgz",
+      "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/eslint-visitor-keys": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
@@ -1186,6 +1205,27 @@
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
       "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g==",
       "dev": true
+    },
+    "@types/express": {
+      "version": "4.17.1",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.1.tgz",
+      "integrity": "sha512-VfH/XCP0QbQk5B5puLqTLEeFgR8lfCJHZJKkInZ9mkYd+u8byX0kztXEQxEk4wZXJs8HI+7km2ALXjn4YKcX9w==",
+      "dev": true,
+      "requires": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "@types/express-serve-static-core": {
+      "version": "4.16.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz",
+      "integrity": "sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/range-parser": "*"
+      }
     },
     "@types/glob": {
       "version": "7.1.1",
@@ -1229,6 +1269,12 @@
       "integrity": "sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==",
       "dev": true
     },
+    "@types/mime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
+      "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "dev": true
+    },
     "@types/minimatch": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1245,6 +1291,31 @@
       "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==",
       "dev": true
+    },
+    "@types/passport": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.1.tgz",
+      "integrity": "sha512-oK87JjN8i8kmqb0RN0sCUB/ZjrWf3b8U45eAzZVy1ssYYgBrMOuALmvoqp7MglsilXAjxum+LS29VQqeQx6ddA==",
+      "dev": true,
+      "requires": {
+        "@types/express": "*"
+      }
+    },
+    "@types/range-parser": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
+      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "dev": true
+    },
+    "@types/serve-static": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
+      "dev": true,
+      "requires": {
+        "@types/express-serve-static-core": "*",
+        "@types/mime": "*"
+      }
     },
     "@types/stack-utils": {
       "version": "1.0.1",
@@ -3364,6 +3435,12 @@
         "es5-ext": "^0.10.35",
         "es6-symbol": "^3.1.1"
       }
+    },
+    "es6-promise": {
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
@@ -8777,6 +8854,18 @@
       "dev": true,
       "requires": {
         "passport-strategy": "1.x.x"
+      }
+    },
+    "passport-mock-strategy": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-mock-strategy/-/passport-mock-strategy-2.0.0.tgz",
+      "integrity": "sha512-9YUT0sja/7n+HfQ+Jwx4XETERRh1uciRjpHhEZMcYS1FBnMrfrSlKVS42bMU06ewSFiPhXztazAE6XwiZdZQ/g==",
+      "dev": true,
+      "requires": {
+        "@types/express": "^4.16.1",
+        "@types/passport": "^1.0.0",
+        "es6-promise": "^4.2.6",
+        "passport": "^0.4.0"
       }
     },
     "passport-strategy": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,8 @@
     "passport-http-bearer": "^1.0.1",
     "prettier": "^1.18.2",
     "prettier-eslint": "^9.0.0",
-    "supertest": "^4.0.2"
+    "superagent-use": "^0.1.0",
+    "supertest": "^4.0.2",
+    "supertest-capture-error": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "oauth2orize": "^1.11.0",
     "opener": "^1.5.1",
     "passport-http-bearer": "^1.0.1",
+    "passport-mock-strategy": "^2.0.0",
     "prettier": "^1.18.2",
     "prettier-eslint": "^9.0.0",
     "superagent-use": "^0.1.0",

--- a/schema/15.do.drop-nic-millipercent.sql
+++ b/schema/15.do.drop-nic-millipercent.sql
@@ -1,0 +1,1 @@
+alter table preparation drop column nicotine_millipercent;

--- a/schema/15.undo.drop-nic-millipercent.sql
+++ b/schema/15.undo.drop-nic-millipercent.sql
@@ -1,0 +1,2 @@
+alter table preparation
+  add column nicotine_millipercent numeric(4, 4) default 0;

--- a/src/models/preparation.js
+++ b/src/models/preparation.js
@@ -28,10 +28,6 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.DECIMAL(4, 0),
         allowNull: false
       },
-      nicotineMillipercent: {
-        type: DataTypes.DECIMAL,
-        allowNull: false
-      },
       created: {
         type: DataTypes.DATE,
         allowNull: false,
@@ -39,7 +35,8 @@ module.exports = (sequelize, DataTypes) => {
       },
       viewCount: {
         type: DataTypes.INTEGER,
-        allowNull: false
+        allowNull: false,
+        defaultValue: 0
       }
     },
     {
@@ -63,6 +60,10 @@ module.exports = (sequelize, DataTypes) => {
       through: models.PreparationsDiluents,
       foreignKey: 'preparationId',
       otherKey: 'diluentId'
+    });
+    this.hasMany(models.PreparationsDiluents, {
+      as: 'PreparationDiluents',
+      foreignKey: 'preparationId'
     });
   };
 

--- a/src/models/recipe.js
+++ b/src/models/recipe.js
@@ -51,7 +51,8 @@ module.exports = (sequelize, DataTypes) => {
       },
       viewCount: {
         type: DataTypes.INTEGER,
-        allowNull: false
+        allowNull: false,
+        defaultValue: 0
       }
     },
     {
@@ -82,6 +83,14 @@ module.exports = (sequelize, DataTypes) => {
       through: models.RecipesDiluents,
       foreignKey: 'recipeId',
       otherKey: 'diluentId'
+    });
+    this.hasMany(models.RecipesFlavors, {
+      as: 'RecipeFlavors',
+      foreignKey: 'recipeId'
+    });
+    this.hasMany(models.RecipesDiluents, {
+      as: 'RecipeDiluents',
+      foreignKey: 'recipeId'
     });
     this.hasMany(models.Preparation, {
       foreignKey: 'recipeId'

--- a/src/models/recipesFlavors.js
+++ b/src/models/recipesFlavors.js
@@ -36,7 +36,7 @@ module.exports = (sequelize, DataTypes) => {
 
   RecipesFlavors.associate = function(models) {
     this.belongsTo(models.Recipe, { foreignKey: 'recipeId' });
-    this.belongsTo(models.Flavor, { foreignKey: 'FlavorId' });
+    this.belongsTo(models.Flavor, { foreignKey: 'flavorId' });
   };
 
   return RecipesFlavors;

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -12,6 +12,7 @@ import {
   generateToken,
   isTestEnvironment
 } from './util';
+import MockStrategy from 'passport-mock-strategy';
 
 const log = loggers('auth');
 const { Op } = models.Sequelize;
@@ -181,6 +182,14 @@ export const ensureRole = name => async (req, _, next) => {
     next(error);
   }
 };
+
+export const useMockStrategy = (passportRef, user) =>
+  passportRef.use(
+    new MockStrategy({
+      name: 'anonymous',
+      user
+    })
+  );
 
 export default app => {
   passport.use(

--- a/src/modules/util.js
+++ b/src/modules/util.js
@@ -1,5 +1,8 @@
 import nanoid from 'nanoid';
+import use from 'superagent-use';
+import supertest from 'supertest';
 import { hash as create, compare } from 'bcrypt';
+import captureError from 'supertest-capture-error';
 
 import configs from './config';
 
@@ -32,3 +35,10 @@ export const buildWebUrl = path => {
 };
 
 export const isTestEnvironment = () => process.env.NODE_ENV === 'test';
+
+export const captureTestErrors = app =>
+  use(supertest(app)).use(
+    captureError((error, test) => {
+      error.message += `\nURL: ${test.url}\nResponse: ${test.res.text}`;
+    })
+  );

--- a/src/routes/data.test.js
+++ b/src/routes/data.test.js
@@ -1,11 +1,11 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 import bodyParser from 'body-parser';
 
 import data from './data';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
 describe('data route resource', () => {
   const app = express();
@@ -14,6 +14,8 @@ describe('data route resource', () => {
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(data);
+
+  const request = captureTestErrors(app);
 
   afterAll(() => {
     database.sequelize.close();
@@ -27,45 +29,37 @@ describe('data route resource', () => {
   };
 
   it('GET returns 404 for missing route', done => {
-    request(app)
-      .get('/')
-      .expect(404, done);
+    request.get('/').expect(404, done);
   });
 
   it('GET returns 404 for missing route with id', done => {
-    request(app)
-      .get('/1')
-      .expect(404, done);
+    request.get('/1').expect(404, done);
   });
 
   it('PUT returns 404 for missing route', done => {
-    request(app)
+    request
       .put('/')
       .send(mockData)
       .expect(404, done);
   });
 
   it('POST returns 404 for missing route', done => {
-    request(app)
+    request
       .post('/')
       .send(mockData)
       .expect(404, done);
   });
 
   it('DELETE returns 404 for deleting without an id', done => {
-    request(app)
-      .delete('/')
-      .expect(404, done);
+    request.delete('/').expect(404, done);
   });
 
   it('GET returns 200 for data supplier id', done => {
-    request(app)
-      .get('/supplier/1')
-      .expect(200, done);
+    request.get('/supplier/1').expect(200, done);
   });
 
   it('POST returns 200 for creating data supplier', done => {
-    request(app)
+    request
       .post('/supplier')
       .send({ name: 'Juicy Co', code: 'JC' })
       .expect('Content-type', /json/)
@@ -73,7 +67,7 @@ describe('data route resource', () => {
   });
 
   it('PUT returns 200 for updating data supplier', done => {
-    request(app)
+    request
       .put('/supplier/14')
       .send({ name: 'Juicy Co', code: 'JC' })
       .expect('Content-type', /json/)
@@ -81,21 +75,17 @@ describe('data route resource', () => {
   });
 
   it('DELETE returns 200 for deleting data supplier', done => {
-    request(app)
+    request
       .delete('/supplier/14')
       .expect('Content-type', /json/)
       .expect(200, done);
   });
 
   it('GET returns 200 for data suppliers', done => {
-    request(app)
-      .get('/suppliers')
-      .expect(200, done);
+    request.get('/suppliers').expect(200, done);
   });
 
   it('GET returns 200 for schema version data', done => {
-    request(app)
-      .get('/version')
-      .expect(200, done);
+    request.get('/version').expect(200, done);
   });
 });

--- a/src/routes/diluent.test.js
+++ b/src/routes/diluent.test.js
@@ -1,11 +1,11 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 import bodyParser from 'body-parser';
 
 import diluent from './diluent';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
 describe('diluent route resource', () => {
   const app = express();
@@ -14,6 +14,8 @@ describe('diluent route resource', () => {
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(diluent);
+
+  const request = captureTestErrors(app);
 
   afterAll(() => {
     database.sequelize.close();
@@ -27,7 +29,7 @@ describe('diluent route resource', () => {
   };
 
   it('POST returns 200 for creating diluent', done => {
-    request(app)
+    request
       .post('/')
       .send(mockData)
       .expect('Content-type', /json/)
@@ -35,19 +37,15 @@ describe('diluent route resource', () => {
   });
 
   it('GET returns 404 for missing id', done => {
-    request(app)
-      .get('/')
-      .expect(404, done);
+    request.get('/').expect(404, done);
   });
 
   it('GET returns 200 for valid diluent', done => {
-    request(app)
-      .get('/2')
-      .expect(200, done);
+    request.get('/2').expect(200, done);
   });
 
   it('PUT returns 200 for updating diluent', done => {
-    request(app)
+    request
       .put('/3')
       .send(mockData)
       .expect('Content-type', /json/)
@@ -55,33 +53,25 @@ describe('diluent route resource', () => {
   });
 
   it('PUT returns 404 for updating without an id', done => {
-    request(app)
+    request
       .put('/')
       .send(mockData)
       .expect(404, done);
   });
 
   it('GET returns 400 for invalid diluent', done => {
-    request(app)
-      .get('/0')
-      .expect(400, done);
+    request.get('/0').expect(400, done);
   });
 
   it('GET returns 400 for invalid diluent #2', done => {
-    request(app)
-      .get('/ham')
-      .expect(400, done);
+    request.get('/ham').expect(400, done);
   });
 
   it('DELETE returns 200 after deleting diluent', done => {
-    request(app)
-      .delete('/4')
-      .expect(200, done);
+    request.delete('/4').expect(200, done);
   });
 
   it('DELETE returns 404 for deleting without an id', done => {
-    request(app)
-      .delete('/')
-      .expect(404, done);
+    request.delete('/').expect(404, done);
   });
 });

--- a/src/routes/diluents.test.js
+++ b/src/routes/diluents.test.js
@@ -1,49 +1,40 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import diluents from './diluents';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('diluents route resource', () => {
   const app = express();
 
   passport.use(new AnonymousStrategy());
   app.use(diluents);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid list of diluents', done => {
-    request(app)
-      .get('/')
-      .expect(200, done);
+    request.get('/').expect(200, done);
   });
 
   it('returns valid list of 2 diluents', done => {
-    request(app)
-      .get('/?limit=2')
-      .expect(200, done);
+    request.get('/?limit=2').expect(200, done);
   });
 
   it('returns 404 for invalid route', done => {
-    request(app)
-      .get('/3')
-      .expect(404, done);
+    request.get('/3').expect(404, done);
   });
 
   it('returns 200 diluents list', done => {
-    request(app)
-      .get('/?offset=800000')
-      .expect(200, done);
+    request.get('/?offset=800000').expect(200, done);
   });
 
   it('returns 400 for invalid diluents list', done => {
-    request(app)
-      .get('/?limit=stop')
-      .expect(400, done);
+    request.get('/?limit=stop').expect(400, done);
   });
 });

--- a/src/routes/flavor.test.js
+++ b/src/routes/flavor.test.js
@@ -1,11 +1,11 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 import bodyParser from 'body-parser';
 
 import flavor from './flavor';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
 /* eslint-disable camelcase */
 describe('flavor route resource', () => {
@@ -16,18 +16,18 @@ describe('flavor route resource', () => {
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(flavor);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('GET returns valid flavor', done => {
-    request(app)
-      .get('/123')
-      .expect(200, done);
+    request.get('/123').expect(200, done);
   });
 
   it('POST creates flavor', done => {
-    request(app)
+    request
       .post('/')
       .send({
         vendorId: 3,
@@ -39,7 +39,7 @@ describe('flavor route resource', () => {
   });
 
   it('PUT updates flavor', done => {
-    request(app)
+    request
       .put('/801')
       .send({
         vendorId: 3,
@@ -51,53 +51,43 @@ describe('flavor route resource', () => {
   });
 
   it('DELETE deletes flavor', done => {
-    request(app)
-      .delete('/801')
-      .expect(200, done);
+    request.delete('/801').expect(200, done);
   });
 
   it('GET returns valid flavor identifiers', done => {
-    request(app)
-      .get('/1/identifiers')
-      .expect(200, done);
+    request.get('/1/identifiers').expect(200, done);
   });
 
   it('GET returns valid flavor identifier', done => {
-    request(app)
-      .get('/1/identifier/1')
-      .expect(200, done);
+    request.get('/1/identifier/1').expect(200, done);
   });
 
   it('POST creates valid flavor identifier', done => {
-    request(app)
+    request
       .post('/1/identifier')
       .send({ dataSupplierId: 1, identifier: 'cap_27-bears' })
       .expect(200, done);
   });
 
   it('PUT updates valid flavor identifier', done => {
-    request(app)
+    request
       .put('/1/identifier/1')
       .send({ identifier: 'cap_27-bears' })
       .expect(200, done);
   });
 
   it('DELETE deletes flavor identifier', done => {
-    request(app)
+    request
       .delete('/1/identifier/1')
       .send({ identifier: 'cap_27-bears' })
       .expect(200, done);
   });
 
   it('returns 400 for missing flavor', done => {
-    request(app)
-      .get('/0')
-      .expect(400, done);
+    request.get('/0').expect(400, done);
   });
 
   it('returns 400 for invalid flavor', done => {
-    request(app)
-      .get('/ham')
-      .expect(400, done);
+    request.get('/ham').expect(400, done);
   });
 });

--- a/src/routes/flavors.test.js
+++ b/src/routes/flavors.test.js
@@ -1,37 +1,32 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import flavors from './flavors';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('flavors route resource', () => {
   const app = express();
 
   passport.use(new AnonymousStrategy());
   app.use(flavors);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid list of 2 flavors', done => {
-    request(app)
-      .get('/?limit=2')
-      .expect(200, done);
+    request.get('/?limit=2').expect(200, done);
   });
 
   it('returns 200 for missing flavors list', done => {
-    request(app)
-      .get('/?offset=800000')
-      .expect(200, done);
+    request.get('/?offset=800000').expect(200, done);
   });
 
   it('returns 400 for invalid flavor list', done => {
-    request(app)
-      .get('/?limit=stop')
-      .expect(400, done);
+    request.get('/?limit=stop').expect(400, done);
   });
 });

--- a/src/routes/preparation.test.js
+++ b/src/routes/preparation.test.js
@@ -1,11 +1,11 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import bodyParser from 'body-parser';
 import AnonymousStrategy from 'passport-anonymous';
 
 import preparationRoute from './preparation';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
 describe('preparation route resource', () => {
   const app = express();
@@ -14,6 +14,8 @@ describe('preparation route resource', () => {
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(preparationRoute);
+
+  const request = captureTestErrors(app);
 
   afterAll(() => {
     database.sequelize.close();
@@ -48,7 +50,7 @@ describe('preparation route resource', () => {
   };
 
   it('can create preparation', done => {
-    request(app)
+    request
       .post('/')
       .send(mockData)
       .expect('Content-Type', /json/)
@@ -56,14 +58,14 @@ describe('preparation route resource', () => {
   });
 
   it('can request valid preparation', done => {
-    request(app)
+    request
       .get('/123')
       .expect('Content-Type', /json/)
       .expect(200, done);
   });
 
   it('can update existing preparation', done => {
-    request(app)
+    request
       .put('/123')
       .send(mockData)
       .expect('Content-Type', /json/)
@@ -71,21 +73,21 @@ describe('preparation route resource', () => {
   });
 
   it('can delete existing preparation', done => {
-    request(app)
+    request
       .delete('/123')
       .expect('Content-Type', /json/)
       .expect(200, done);
   });
 
   it('returns 400 for invalid number in GET request', done => {
-    request(app)
+    request
       .get('/0')
       .expect('Content-Type', /json/)
       .expect(400, done);
   });
 
   it('returns 400 for string in GET request', done => {
-    request(app)
+    request
       .get('/ham')
       .expect('Content-Type', /json/)
       .expect(400, done);

--- a/src/routes/preparations.test.js
+++ b/src/routes/preparations.test.js
@@ -1,37 +1,32 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import preparations from './preparations';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('preparations route resource', () => {
   const app = express();
 
   passport.use(new AnonymousStrategy());
   app.use(preparations);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid list of 2 preparations', done => {
-    request(app)
-      .get('/?limit=2')
-      .expect(200, done);
+    request.get('/?limit=2').expect(200, done);
   });
 
   it('returns 200 for preparations list', done => {
-    request(app)
-      .get('/?offset=9000000')
-      .expect(200, done);
+    request.get('/?offset=9000000').expect(200, done);
   });
 
   it('returns 400 for invalid preparations list', done => {
-    request(app)
-      .get('/?limit=stop')
-      .expect(400, done);
+    request.get('/?limit=stop').expect(400, done);
   });
 });

--- a/src/routes/recipe.js
+++ b/src/routes/recipe.js
@@ -187,14 +187,15 @@ router.post(
     }
   }
 );
+
 /**
  * PUT Update Recipe
  * @param id int
  * @body userId int
  * @body name string
  * @body notes string
- * @body RecipesFlavors array
- * @body RecipesDiluents array
+ * @body flavors array
+ * @body recipeDiluents array
  */
 router.put(
   '/:id',
@@ -211,13 +212,10 @@ router.put(
       .isLength({ min: 1 })
       .withMessage('length'),
     body('notes').isString(),
-    body('RecipesFlavors')
+    body('flavors')
       .isArray()
       .withMessage('array'),
-    body('RecipesDiluents')
-      .isArray()
-      .withMessage('array'),
-    body('PreparationsDiluents')
+    body('recipeDiluents')
       .isArray()
       .withMessage('array')
   ],
@@ -259,7 +257,7 @@ router.put(
 
       const diluentResult = [];
 
-      for (const diluent of req.body.RecipesDiluents) {
+      for (const diluent of req.body.recipeDiluents) {
         if (diluent.millipercent === null) {
           // delete
           diluentResult[diluent.diluentId] = await RecipesDiluents.destroy({
@@ -292,7 +290,7 @@ router.put(
 
       const flavorResult = [];
 
-      for (const flavor of req.body.RecipesFlavors) {
+      for (const flavor of req.body.flavors) {
         if (flavor.millipercent === null) {
           // delete
           flavorResult[flavor.flavorId] = await RecipesFlavors.destroy({

--- a/src/routes/recipe.js
+++ b/src/routes/recipe.js
@@ -114,7 +114,6 @@ router.post(
         {
           userId,
           name,
-          viewCount: 0,
           notes,
           RecipesFlavors: req.body.RecipesFlavors, // Array of flavors
           RecipesDiluents: req.body.RecipesDiluents // Array of diluents

--- a/src/routes/recipe.test.js
+++ b/src/routes/recipe.test.js
@@ -1,11 +1,11 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import bodyParser from 'body-parser';
 import AnonymousStrategy from 'passport-anonymous';
 
 import recipeRoute from './recipe';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
 describe('recipe route resource', () => {
   const app = express();
@@ -14,6 +14,8 @@ describe('recipe route resource', () => {
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(recipeRoute);
+
+  const request = captureTestErrors(app);
 
   afterAll(() => {
     database.sequelize.close();
@@ -50,7 +52,7 @@ describe('recipe route resource', () => {
   };
 
   it('can create recipe', done => {
-    request(app)
+    request
       .post('/')
       .send(mockData)
       .expect('Content-Type', /json/)
@@ -58,14 +60,14 @@ describe('recipe route resource', () => {
   });
 
   it('can request valid recipe', done => {
-    request(app)
+    request
       .get('/123')
       .expect('Content-Type', /json/)
       .expect(200, done);
   });
 
   it('can update existing recipe', done => {
-    request(app)
+    request
       .put('/123')
       .send(mockData)
       .expect('Content-Type', /json/)
@@ -73,21 +75,21 @@ describe('recipe route resource', () => {
   });
 
   it('can delete existing recipe', done => {
-    request(app)
+    request
       .delete('/123')
       .expect('Content-Type', /json/)
       .expect(200, done);
   });
 
   it('returns 400 for invalid number in GET request', done => {
-    request(app)
+    request
       .get('/0')
       .expect('Content-Type', /json/)
       .expect(400, done);
   });
 
   it('returns 400 for string in GET request', done => {
-    request(app)
+    request
       .get('/ham')
       .expect('Content-Type', /json/)
       .expect(400, done);

--- a/src/routes/recipe.test.js
+++ b/src/routes/recipe.test.js
@@ -24,8 +24,10 @@ describe('recipe route resource', () => {
   const mockData = {
     userId: 4,
     name: 'Testing',
+    version: 1,
     notes: 'A strawberry mint lemonade cheesecake concoction',
-    RecipesFlavors: [
+    volumeMl: 60,
+    flavors: [
       {
         flavorId: 1,
         millipercent: 10
@@ -39,7 +41,7 @@ describe('recipe route resource', () => {
         millipercent: 100
       }
     ],
-    RecipesDiluents: [
+    recipeDiluents: [
       {
         diluentId: 1,
         millipercent: 8000
@@ -48,7 +50,8 @@ describe('recipe route resource', () => {
         diluentId: 2,
         millipercent: 1000
       }
-    ]
+    ],
+    preparationDiluents: []
   };
 
   it('can create recipe', done => {

--- a/src/routes/recipe.test.js
+++ b/src/routes/recipe.test.js
@@ -1,16 +1,16 @@
 import express from 'express';
 import passport from 'passport';
 import bodyParser from 'body-parser';
-import AnonymousStrategy from 'passport-anonymous';
 
 import recipeRoute from './recipe';
 import database from '../modules/database';
+import { useMockStrategy } from '../modules/auth';
 import { captureTestErrors } from '../modules/util';
 
 describe('recipe route resource', () => {
   const app = express();
 
-  passport.use(new AnonymousStrategy());
+  useMockStrategy(passport, { id: 1 });
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(recipeRoute);

--- a/src/routes/recipes.test.js
+++ b/src/routes/recipes.test.js
@@ -1,10 +1,10 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import recipes from './recipes';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
 /* eslint-disable camelcase */
 describe('recipes route resource', () => {
@@ -13,25 +13,21 @@ describe('recipes route resource', () => {
   passport.use(new AnonymousStrategy());
   app.use(recipes);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid list of 2 recipes', done => {
-    request(app)
-      .get('/?limit=2')
-      .expect(200, done);
+    request.get('/?limit=2').expect(200, done);
   });
 
   it('returns 200 for recipes list', done => {
-    request(app)
-      .get('/?offset=9000000')
-      .expect(200, done);
+    request.get('/?offset=9000000').expect(200, done);
   });
 
   it('returns 400 for invalid recipes list', done => {
-    request(app)
-      .get('/?limit=stop')
-      .expect(400, done);
+    request.get('/?limit=stop').expect(400, done);
   });
 });

--- a/src/routes/register.test.js
+++ b/src/routes/register.test.js
@@ -1,13 +1,12 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import bodyParser from 'body-parser';
 import AnonymousStrategy from 'passport-anonymous';
 
 import register from './register';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('register route resource', () => {
   const app = express();
 
@@ -16,12 +15,14 @@ describe('register route resource', () => {
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(register);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('can register user', done => {
-    request(app)
+    request
       .post('/')
       .send({
         emailAddress: 'example@example.com',
@@ -32,20 +33,14 @@ describe('register route resource', () => {
   });
 
   it('returns 400 for registration error (no data)', done => {
-    request(app)
-      .post('/')
-      .expect(400, done);
+    request.post('/').expect(400, done);
   });
 
   it('returns 400 for token error (invalid token)', done => {
-    request(app)
-      .get('/activate/?code=123456')
-      .expect(400, done);
+    request.get('/activate/?code=123456').expect(400, done);
   });
 
   it('returns 400 for token error (missing token)', done => {
-    request(app)
-      .get('/activate')
-      .expect(400, done);
+    request.get('/activate').expect(400, done);
   });
 });

--- a/src/routes/role.test.js
+++ b/src/routes/role.test.js
@@ -1,13 +1,12 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 import bodyParser from 'body-parser';
 
 import role from './role';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('role route resource', () => {
   const app = express();
 
@@ -15,6 +14,8 @@ describe('role route resource', () => {
   app.use(bodyParser.json());
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(role);
+
+  const request = captureTestErrors(app);
 
   afterAll(() => {
     database.sequelize.close();
@@ -25,7 +26,7 @@ describe('role route resource', () => {
   };
 
   it('POST returns 200 for creating role', done => {
-    request(app)
+    request
       .post('/')
       .send(mockData)
       .expect('Content-type', /json/)
@@ -33,13 +34,11 @@ describe('role route resource', () => {
   });
 
   it('GET returns 200 for valid role', done => {
-    request(app)
-      .get('/5')
-      .expect(200, done);
+    request.get('/5').expect(200, done);
   });
 
   it('PUT returns 200 for updating role', done => {
-    request(app)
+    request
       .put('/6')
       .send(mockData)
       .expect('Content-type', /json/)
@@ -47,20 +46,14 @@ describe('role route resource', () => {
   });
 
   it('GET returns 400 for invalid role', done => {
-    request(app)
-      .get('/0')
-      .expect(400, done);
+    request.get('/0').expect(400, done);
   });
 
   it('GET returns 404 for invalid role route', done => {
-    request(app)
-      .get('/ham')
-      .expect(404, done);
+    request.get('/ham').expect(404, done);
   });
 
   it('DELETE returns 200 after deleting role', done => {
-    request(app)
-      .delete('/15')
-      .expect(200, done);
+    request.delete('/15').expect(200, done);
   });
 });

--- a/src/routes/roles.test.js
+++ b/src/routes/roles.test.js
@@ -1,31 +1,28 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import roles from './roles';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('roles route resource', () => {
   const app = express();
 
   passport.use(new AnonymousStrategy());
   app.use(roles);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid roles', done => {
-    request(app)
-      .get('/')
-      .expect(200, done);
+    request.get('/').expect(200, done);
   });
 
   it('returns 404 for page not found', done => {
-    request(app)
-      .get('/error')
-      .expect(404, done);
+    request.get('/error').expect(404, done);
   });
 });

--- a/src/routes/stats.test.js
+++ b/src/routes/stats.test.js
@@ -1,31 +1,28 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import stats from './stats';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('stats route resource', () => {
   const app = express();
 
   passport.use(new AnonymousStrategy());
   app.use(stats);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid stats', done => {
-    request(app)
-      .get('/dashboard')
-      .expect(200, done);
+    request.get('/dashboard').expect(200, done);
   });
 
   it('returns 404 for page not found', done => {
-    request(app)
-      .get('/error')
-      .expect(404, done);
+    request.get('/error').expect(404, done);
   });
 });

--- a/src/routes/user.test.js
+++ b/src/routes/user.test.js
@@ -1,13 +1,12 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 import bodyParser from 'body-parser';
 
 import user from './user';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('user route resource', () => {
   const app = express();
 
@@ -16,24 +15,22 @@ describe('user route resource', () => {
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(user);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('GET returns valid user', done => {
-    request(app)
-      .get('/7')
-      .expect(200, done);
+    request.get('/7').expect(200, done);
   });
 
   it('GET returns valid user profile', done => {
-    request(app)
-      .get('/7/profile')
-      .expect(200, done);
+    request.get('/7/profile').expect(200, done);
   });
 
   it('PUT updates user profile', done => {
-    request(app)
+    request
       .put('/7/profile')
       .send({
         bio: 'eMixer',
@@ -45,13 +42,11 @@ describe('user route resource', () => {
   });
 
   it('GET returns valid user recipes', done => {
-    request(app)
-      .get('/8/recipes')
-      .expect(200, done);
+    request.get('/8/recipes').expect(200, done);
   });
 
   it('POST adds user flavor', done => {
-    request(app)
+    request
       .post('/9/flavor')
       .send({
         flavorId: 20
@@ -61,13 +56,11 @@ describe('user route resource', () => {
   });
 
   it('GET returns valid user flavor', done => {
-    request(app)
-      .get('/10/flavor/3')
-      .expect(200, done);
+    request.get('/10/flavor/3').expect(200, done);
   });
 
   it('PUT updates user flavor', done => {
-    request(app)
+    request
       .put('/7/flavor/123')
       .send({
         minMillipercent: 50,
@@ -78,31 +71,23 @@ describe('user route resource', () => {
   });
 
   it('GET returns valid user flavors', done => {
-    request(app)
-      .get('/10/flavors')
-      .expect(200, done);
+    request.get('/10/flavors').expect(200, done);
   });
 
   it('DELETE deletes a user flavor', done => {
-    request(app)
-      .delete('/11/flavor/200')
-      .expect(200, done);
+    request.delete('/11/flavor/200').expect(200, done);
   });
 
   it('GET returns valid user roles', done => {
-    request(app)
-      .get('/10/roles')
-      .expect(200, done);
+    request.get('/10/roles').expect(200, done);
   });
 
   it('GET returns a valid user role', done => {
-    request(app)
-      .get('/10/role/1')
-      .expect(200, done);
+    request.get('/10/role/1').expect(200, done);
   });
 
   it('POST assigns a user role', done => {
-    request(app)
+    request
       .post('/9/role/')
       .send({
         roleId: 3,
@@ -113,7 +98,7 @@ describe('user route resource', () => {
   });
 
   it('PUT updates a user role', done => {
-    request(app)
+    request
       .put('/9/role/3')
       .send({
         active: true
@@ -123,25 +108,19 @@ describe('user route resource', () => {
   });
 
   it('DELETE deletes a user role', done => {
-    request(app)
-      .delete('/11/role/1')
-      .expect(200, done);
+    request.delete('/11/role/1').expect(200, done);
   });
 
   it('returns 200 for missing user', done => {
-    request(app)
-      .get('/100000000')
-      .expect(200, done);
+    request.get('/100000000').expect(200, done);
   });
 
   it('returns 400 for invalid user', done => {
-    request(app)
-      .get('/0')
-      .expect(400, done);
+    request.get('/0').expect(400, done);
   });
 
   it('GET current user', done => {
-    request(app)
+    request
       .get('/current')
       .expect('Content-Type', /json/)
       .expect(200, done);

--- a/src/routes/users.test.js
+++ b/src/routes/users.test.js
@@ -1,10 +1,10 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import users from './users';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
 /* eslint-disable camelcase */
 describe('users route resource', () => {
@@ -13,49 +13,37 @@ describe('users route resource', () => {
   passport.use(new AnonymousStrategy());
   app.use(users);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid list of 2 users', done => {
-    request(app)
-      .get('/?limit=2')
-      .expect(200, done);
+    request.get('/?limit=2').expect(200, done);
   });
 
   it('returns 200 for user list', done => {
-    request(app)
-      .get('/?offset=9000000')
-      .expect(200, done);
+    request.get('/?offset=9000000').expect(200, done);
   });
 
   it('returns 400 for invalid user list', done => {
-    request(app)
-      .get('/?limit=stop')
-      .expect(400, done);
+    request.get('/?limit=stop').expect(400, done);
   });
 
   it('returns valid list of 2 user accounts', done => {
-    request(app)
-      .get('/accounts/?limit=2')
-      .expect(200, done);
+    request.get('/accounts/?limit=2').expect(200, done);
   });
 
   it('returns 200 for user accounts list', done => {
-    request(app)
-      .get('/accounts/?offset=9000000')
-      .expect(200, done);
+    request.get('/accounts/?offset=9000000').expect(200, done);
   });
 
   it('returns 400 for invalid user accounts list', done => {
-    request(app)
-      .get('/accounts/?limit=stop')
-      .expect(400, done);
+    request.get('/accounts/?limit=stop').expect(400, done);
   });
 
   it('returns 200 for roles users list', done => {
-    request(app)
-      .get('/role/1')
-      .expect(200, done);
+    request.get('/role/1').expect(200, done);
   });
 });

--- a/src/routes/vendor.test.js
+++ b/src/routes/vendor.test.js
@@ -1,13 +1,12 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 import bodyParser from 'body-parser';
 
 import vendor from './vendor';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('vendor route resource', () => {
   const app = express();
 
@@ -16,18 +15,18 @@ describe('vendor route resource', () => {
   app.use(bodyParser.urlencoded({ extended: false }));
   app.use(vendor);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid vendor', done => {
-    request(app)
-      .get('/1')
-      .expect(200, done);
+    request.get('/1').expect(200, done);
   });
 
   it('POST creates vendor', done => {
-    request(app)
+    request
       .post('/')
       .send({
         vendorId: 3,
@@ -39,7 +38,7 @@ describe('vendor route resource', () => {
   });
 
   it('PUT updates vendor', done => {
-    request(app)
+    request
       .put('/801')
       .send({
         vendorId: 3,
@@ -51,51 +50,41 @@ describe('vendor route resource', () => {
   });
 
   it('DELETE deletes vendor', done => {
-    request(app)
-      .delete('/801')
-      .expect(200, done);
+    request.delete('/801').expect(200, done);
   });
 
   it('returns 200 for vendor', done => {
-    request(app)
-      .get('/20000')
-      .expect(200, done);
+    request.get('/20000').expect(200, done);
   });
 
   it('returns 400 for invalid vendor', done => {
-    request(app)
-      .get('/ham')
-      .expect(400, done);
+    request.get('/ham').expect(400, done);
   });
 
   it('GET returns valid vendor identifiers', done => {
-    request(app)
-      .get('/1/identifiers')
-      .expect(200, done);
+    request.get('/1/identifiers').expect(200, done);
   });
 
   it('GET returns valid vendor identifier', done => {
-    request(app)
-      .get('/1/identifier/1')
-      .expect(200, done);
+    request.get('/1/identifier/1').expect(200, done);
   });
 
   it('POST creates valid vendor identifier', done => {
-    request(app)
+    request
       .post('/1/identifier')
       .send({ dataSupplierId: 1, identifier: 'capellar' })
       .expect(200, done);
   });
 
   it('PUT updates valid vendor identifier', done => {
-    request(app)
+    request
       .put('/1/identifier/1')
       .send({ identifier: 'capellary' })
       .expect(200, done);
   });
 
   it('DELETE deletes vendor identifier', done => {
-    request(app)
+    request
       .delete('/1/identifier/1')
       .send({ identifier: 'cap_27-bears' })
       .expect(200, done);

--- a/src/routes/vendors.test.js
+++ b/src/routes/vendors.test.js
@@ -1,43 +1,36 @@
 import express from 'express';
-import request from 'supertest';
 import passport from 'passport';
 import AnonymousStrategy from 'passport-anonymous';
 
 import vendors from './vendors';
 import database from '../modules/database';
+import { captureTestErrors } from '../modules/util';
 
-/* eslint-disable camelcase */
 describe('vendors route resource', () => {
   const app = express();
 
   passport.use(new AnonymousStrategy());
   app.use(vendors);
 
+  const request = captureTestErrors(app);
+
   afterAll(() => {
     database.sequelize.close();
   });
 
   it('returns valid vendors', done => {
-    request(app)
-      .get('/?limit=20')
-      .expect(200, done);
+    request.get('/?limit=20').expect(200, done);
   });
 
   it('returns 200 vendors', done => {
-    request(app)
-      .get('/?offset=1000000')
-      .expect(200, done);
+    request.get('/?offset=1000000').expect(200, done);
   });
 
   it('returns 400 for invalid vendors', done => {
-    request(app)
-      .get('/?offset=stop')
-      .expect(400, done);
+    request.get('/?offset=stop').expect(400, done);
   });
 
   it('returns 400 for invalid vendors #2', done => {
-    request(app)
-      .get('/?offset=stop')
-      .expect(400, done);
+    request.get('/?offset=stop').expect(400, done);
   });
 });


### PR DESCRIPTION
This PR makes the following changes:

* [Remove](https://github.com/mixnjuice/api/compare/master...ayan4m1:refactor/recipe-save?expand=1#diff-1e9c19ced524f8338efda6afe5e9b8afR1) a vestigial column from the preparation table
* [Set defaults](https://github.com/mixnjuice/api/compare/master...ayan4m1:refactor/recipe-save?expand=1#diff-5fff0d60851d23c3f1abb464c4a8b594R39) for viewCount fields
* [Adds](https://github.com/mixnjuice/api/compare/master...ayan4m1:refactor/recipe-save?expand=1#diff-9dc1f788cd7f661a552c2e001c185d20R87-R94) associations that make persistence of a recipe easier (no need to do lookups before inserting)
* [Overhaul](https://github.com/mixnjuice/api/compare/master...ayan4m1:refactor/recipe-save?expand=1#diff-fb331442c9dfca487b57de25ad9e179bR122-R128) the recipe request body to include required fields to persist a recipe from the UI
* [Insert](https://github.com/mixnjuice/api/compare/master...ayan4m1:refactor/recipe-save?expand=1#diff-fb331442c9dfca487b57de25ad9e179bR164-L140) a `preparation` row for each new recipe created with nicotine information persisted
* [Adds](https://github.com/mixnjuice/api/compare/master...ayan4m1:refactor/recipe-save?expand=1#diff-fb331442c9dfca487b57de25ad9e179bR218-R220) PreparationsDiluents field for future use in recipe updates