### PR TITLE
Replace @gusta/sequelize-mock with @mixnjuice/sequelize-mock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -845,25 +845,6 @@
         "minimist": "^1.2.0"
       }
     },
-    "@gusta/sequelize-mock": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@gusta/sequelize-mock/-/sequelize-mock-0.11.0.tgz",
-      "integrity": "sha512-rCQzVh9MqGrnbLfHu25hCldadWHkqJDF4ZDxOC0JrJ2O1zYpZ+eSJprojRAt1cZxWF1ezXvOlTf7oSDJQjwhWQ==",
-      "dev": true,
-      "requires": {
-        "bluebird": "^3.5.5",
-        "inflection": "^1.12.0",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.15",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-          "dev": true
-        }
-      }
-    },
     "@jest/console": {
       "version": "24.9.0",
       "resolved": "https://registry.npmjs.org/@jest/console/-/console-24.9.0.tgz",
@@ -1097,6 +1078,17 @@
         "@types/istanbul-lib-coverage": "^2.0.0",
         "@types/istanbul-reports": "^1.1.1",
         "@types/yargs": "^13.0.0"
+      }
+    },
+    "@mixnjuice/sequelize-mock": {
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/@mixnjuice/sequelize-mock/-/sequelize-mock-0.11.1.tgz",
+      "integrity": "sha512-V1FgLUaYbdpbG0LZONBQH+aFyIh0piN+8MQinwTlx+/66ghuYyS5YmsfHzsWuFWNXZxKccdRwDNq5CeuTmPerA==",
+      "dev": true,
+      "requires": {
+        "bluebird": "^3.5.5",
+        "inflection": "^1.12.0",
+        "lodash": "^4.17.15"
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@babel/plugin-transform-runtime": "^7.6.0",
     "@babel/preset-env": "^7.6.0",
     "@babel/register": "^7.6.0",
-    "@gusta/sequelize-mock": "^0.11.0",
+    "@mixnjuice/sequelize-mock": "^0.11.1",
     "babel-eslint": "^10.0.3",
     "cross-env": "^5.2.1",
     "eslint": "^6.0.1",

--- a/src/modules/database.js
+++ b/src/modules/database.js
@@ -1,5 +1,5 @@
 import pick from 'lodash/pick';
-import SequelizeMock from '@gusta/sequelize-mock';
+import SequelizeMock from '@mixnjuice/sequelize-mock';
 import Sequelize, { ValidationError, DatabaseError } from 'sequelize';
 
 import logging from './logging';


### PR DESCRIPTION
This PR replaces the old package under the `gusta` npm namespace with the new `mixnjuice` name space. Code should be the same.