### PR TITLE
Fix codecov env var setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,15 +9,10 @@ jobs:
     working_directory: ~/gusta-api
     steps:
       - checkout
-      - run:
-          name: Set environment variables
-          command: |
-            echo 'export CODECOV_TOKEN="$CODECOV_TOKEN_API"' >> $BASH_ENV
-            source $BASH_ENV
       - run: docker-compose up -d
       - run: docker-compose exec api npm run migrate
       - run: docker-compose exec api npm test
-      - run: docker-compose exec api bash "CODECOV_TOKEN=$CODECOV_TOKEN_API npx codecov"
+      - run: docker-compose exec -e CODECOV_TOKEN=$CODECOV_TOKEN_API api bash npx codecov
   notify_success:
     docker:
       - image: byrnedo/alpine-curl:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: docker-compose up -d
       - run: docker-compose exec api npm run migrate
       - run: docker-compose exec api npm test
-      - run: docker-compose exec api bash "bash <(curl -s https://codecov.io/env)) && npx codecov"
+      - run: docker-compose exec api bash -c "bash <(curl -s https://codecov.io/env)) && npx codecov"
   notify_success:
     docker:
       - image: byrnedo/alpine-curl:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: docker-compose up -d
       - run: docker-compose exec api npm run migrate
       - run: docker-compose exec api npm test
-      - run: docker-compose exec api bash "$(bash <(curl -s https://codecov.io/env)) && npx codecov"
+      - run: docker-compose exec api bash "bash <(curl -s https://codecov.io/env)) && npx codecov"
   notify_success:
     docker:
       - image: byrnedo/alpine-curl:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: docker-compose up -d
       - run: docker-compose exec api npm run migrate
       - run: docker-compose exec api npm test
-      - run: docker-compose exec -e CODECOV_TOKEN=$CODECOV_TOKEN_API api bash npx codecov
+      - run: docker-compose exec api bash "$(bash <(curl -s https://codecov.io/env)) && npx codecov"
   notify_success:
     docker:
       - image: byrnedo/alpine-curl:latest

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - run: docker-compose up -d
       - run: docker-compose exec api npm run migrate
       - run: docker-compose exec api npm test
-      - run: docker-compose exec api bash -c "bash <(curl -s https://codecov.io/env)) && npx codecov"
+      - run: docker-compose exec api bash -c "bash <(curl -s https://codecov.io/env) && npx codecov"
   notify_success:
     docker:
       - image: byrnedo/alpine-curl:latest


### PR DESCRIPTION
This PR fixes circleci failures introduced by #42 - the codecov line was not exporting its env var correctly and this was causing a build failure.

The change is to use the `-e` argument of `docker exec` to pass the codecov token through to the containerized process.