### PR TITLE
Add recipe share key column

### DIFF
--- a/schema/17.do.recipe-share-key.sql
+++ b/schema/17.do.recipe-share-key.sql
@@ -1,0 +1,1 @@
+alter table recipe add share_key varchar(64) default null;

--- a/schema/17.undo.recipe-share-key.sql
+++ b/schema/17.undo.recipe-share-key.sql
@@ -1,0 +1,1 @@
+alter table recipe drop share_key;

--- a/src/models/recipe.js
+++ b/src/models/recipe.js
@@ -53,6 +53,11 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.INTEGER,
         allowNull: false,
         defaultValue: 0
+      },
+      shareKey: {
+        type: DataTypes.STRING,
+        allowNull: true,
+        defaultValue: null
       }
     },
     {


### PR DESCRIPTION
This PR adds a `share_key` column to the `recipe` table and to the recipe.js model. This field default to null, but when set will allow us to look up a recipe by a shared secret without disclosing its other identifiers.