### PR TITLE
Improve Docker image size, fix Jest hang

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,11 +6,12 @@ orbs:
 jobs:
   build:
     machine:
-      image: circleci/classic:201808-01
+      image: circleci/classic:latest
     working_directory: ~/gusta-api
     steps:
       - checkout
-      - run: docker-compose up -d --build
+      - run: DOCKER_BUILDKIT=1 docker build .
+      - run: docker-compose up -d
       - run: docker-compose exec api npm run migrate
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,7 @@ jobs:
     working_directory: ~/gusta-api
     steps:
       - checkout
-      - run: DOCKER_BUILDKIT=1 docker build .
-      - run: docker-compose up -d
+      - run: docker-compose up -d --build
       - run: docker-compose exec api npm run migrate
       - run:
           command: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12
+FROM node:lts-alpine
 
 WORKDIR /usr/src/flavor-api
 
@@ -8,7 +8,12 @@ COPY . .
 # overwrite config with default
 COPY .env.default .env
 
-RUN chmod +x ./bin/start.sh
+RUN apk add --no-cache dos2unix
+
+RUN apk --no-cache add --virtual builds-deps build-base python
+
+RUN dos2unix ./bin/start.sh && \
+  chmod +x ./bin/start.sh
 
 RUN npm install
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Gusta API
 
+Build status: [![CircleCI](https://circleci.com/gh/mixnjuice/api/tree/master.svg?style=svg)](https://circleci.com/gh/mixnjuice/api/tree/master)
+
+Test coverage: [![codecov](https://codecov.io/gh/mixnjuice/api/branch/master/graph/badge.svg)](https://codecov.io/gh/mixnjuice/api)
+
 This repository contains the express-based API that powers the Gusta Project frontend.
 
 ## libraries

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "start": "node lib/index.js",
     "migrate": "node lib/migrate.js",
     "start-mock": "cross-env API_TOKEN_VALIDATE=false node lib/index.js",
-    "test": "jest --forceExit",
+    "test": "jest",
     "upload-coverage": "bash <(curl -s https://codecov.io/bash)"
   },
   "dependencies": {

--- a/src/modules/utils/test.js
+++ b/src/modules/utils/test.js
@@ -15,10 +15,11 @@ export const captureTestErrors = app =>
     })
   );
 
-export const tryCatch = fn => (...args) => {
+export const tryCatch = fn => done => {
   try {
-    fn(...args);
+    fn(done);
   } catch (error) {
     log.error(error.message, error);
+    done(error);
   }
 };

--- a/src/modules/utils/test.test.js
+++ b/src/modules/utils/test.test.js
@@ -48,7 +48,7 @@ describe('test utilities', () => {
 
       tryCatch(failure)(done);
       expect(failure).toHaveBeenCalled();
-      expect(done).not.toHaveBeenCalled();
+      expect(done).toHaveBeenCalledWith(error);
       expect(mockLog.error).toHaveBeenCalledWith(error.message, error);
     });
   });


### PR DESCRIPTION
* [Change](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/alpine-docker-image?expand=1#diff-3254677a7917c6c01f55212f86c57fbfR1) from Ubuntu to Alpine based base image for Docker builds. This cuts the image size in half and improves build speed. Because Alpine-compatible musl builds are not available for [bcrypt](https://www.npmjs.com/package/bcrypt) we have to [install build deps now](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/alpine-docker-image?expand=1#diff-3254677a7917c6c01f55212f86c57fbfR13)
* [Fix](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/alpine-docker-image?expand=1#diff-3254677a7917c6c01f55212f86c57fbfR15) an issue where building the Docker image on Windows hosts would result in a failure to start because the line endings of start.sh might be invalid
* [Add](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/alpine-docker-image?expand=1#diff-04c6e90faac2675aa89e2176d2eec7d8R3) CircleCI/Codecov badges to README.md
* [Fix](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/alpine-docker-image?expand=1#diff-9d90980a071aa4580c24fa482da40d8eR18) the tryCatch test utility method so that it calls `done` in case of error