### PR TITLE
Refactor config module to export individual concerns

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,7 +3,7 @@ import express from 'express';
 import bodyParser from 'body-parser';
 import responseTime from 'response-time';
 
-import configs from 'modules/config';
+import { api as config } from 'modules/config';
 import loggers from 'modules/logging';
 import bindAuth from 'modules/auth';
 
@@ -25,8 +25,6 @@ import users from 'routes/users';
 import vendor from 'routes/vendor';
 import vendors from 'routes/vendors';
 
-// extract API config and create express app
-const { api: config } = configs;
 const log = loggers('app');
 
 export const app = express();

--- a/src/migrate.js
+++ b/src/migrate.js
@@ -2,7 +2,7 @@ import { join } from 'path';
 import program from 'commander';
 import Postgrator from 'postgrator';
 
-import config from 'modules/config';
+import { database as config } from 'modules/config';
 import loggers from 'modules/logging';
 import packageInfo from '../package.json';
 
@@ -12,7 +12,7 @@ const postgrator = new Postgrator({
   migrationDirectory: join(__dirname, '..', 'schema'),
   driver: 'pg',
   schemaTable: 'schemaversion',
-  ...config.database
+  ...config
 });
 
 const logMigration = migration => {

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -4,7 +4,7 @@ import oauth2orize from 'oauth2orize';
 import BearerStrategy from 'passport-http-bearer';
 import AnonymousStrategy from 'passport-anonymous';
 
-import configs from 'modules/config';
+import { api as webConfig } from 'modules/config';
 import models from 'modules/database';
 import logging from 'modules/logging';
 import { compareHashAndPassword, generateToken } from 'modules/utils';
@@ -15,7 +15,6 @@ const log = logging('auth');
 const { Op } = models.Sequelize;
 const { UserToken, User, Role } = models;
 
-const { api: webConfig } = configs;
 const { age: tokenAge, validate: validateTokens } = webConfig.tokens;
 const { validate: validateRoles } = webConfig.roles;
 

--- a/src/modules/config.js
+++ b/src/modules/config.js
@@ -1,5 +1,10 @@
 import dotenv from 'dotenv';
 
+// utility to test for boolean true
+const trueRegex = /^t(rue|$)$/i;
+
+export const isTrue = value => value === true || trueRegex.test(value);
+
 const result = dotenv.config();
 
 if (result.error) {
@@ -8,42 +13,45 @@ if (result.error) {
 
 const { env: config } = process;
 
-const boolean = /^true$/i;
+export const web = {
+  hostname: config.WEB_HOSTNAME,
+  port: parseInt(config.WEB_PORT, 10),
+  useTls: !config.WEB_USE_TLS || isTrue(config.WEB_USE_TLS)
+};
+
+export const api = {
+  hostname: config.API_HOST,
+  port: parseInt(config.API_PORT, 10),
+  passwords: {
+    saltRounds: parseInt(config.API_PASSWORD_SALT_ROUNDS, 10)
+  },
+  tokens: {
+    length: parseInt(config.API_TOKEN_LENGTH, 10),
+    age: parseInt(config.API_TOKEN_AGE, 10),
+    validate: !config.API_TOKEN_VALIDATE || isTrue(config.API_TOKEN_VALIDATE)
+  },
+  roles: {
+    validate: !config.API_ROLE_VALIDATE || isTrue(config.API_ROLE_VALIDATE)
+  }
+};
+
+export const email = {
+  region: config.AWS_REGION,
+  fromAddress: config.API_EMAIL_FROM_ADDRESS,
+  simulate: !config.API_EMAIL_SIMULATE || isTrue(config.API_EMAIL_SIMULATE)
+};
+
+export const database = {
+  host: config.DB_HOST,
+  port: parseInt(config.DB_PORT, 10),
+  database: config.DB_NAME,
+  username: config.DB_USER,
+  password: config.DB_PASS
+};
 
 export default {
-  web: {
-    hostname: config.WEB_HOSTNAME,
-    port: parseInt(config.WEB_PORT, 10),
-    useTls: !config.WEB_USE_TLS || boolean.test(config.WEB_USE_TLS)
-  },
-  api: {
-    hostname: config.API_HOST,
-    port: parseInt(config.API_PORT, 10),
-    passwords: {
-      saltRounds: parseInt(config.API_PASSWORD_SALT_ROUNDS, 10)
-    },
-    tokens: {
-      length: parseInt(config.API_TOKEN_LENGTH, 10),
-      age: parseInt(config.API_TOKEN_AGE, 10),
-      validate:
-        !config.API_TOKEN_VALIDATE || boolean.test(config.API_TOKEN_VALIDATE)
-    },
-    roles: {
-      validate:
-        !config.API_ROLE_VALIDATE || boolean.test(config.API_ROLE_VALIDATE)
-    }
-  },
-  email: {
-    region: config.AWS_REGION,
-    fromAddress: config.API_EMAIL_FROM_ADDRESS,
-    simulate:
-      !config.API_EMAIL_SIMULATE || boolean.test(config.API_EMAIL_SIMULATE)
-  },
-  database: {
-    host: config.DB_HOST,
-    port: parseInt(config.DB_PORT, 10),
-    database: config.DB_NAME,
-    username: config.DB_USER,
-    password: config.DB_PASS
-  }
+  api,
+  database,
+  email,
+  web
 };

--- a/src/modules/config.test.js
+++ b/src/modules/config.test.js
@@ -1,0 +1,19 @@
+import { isTrue } from './config';
+
+describe('config module', () => {
+  describe('isTrue', () => {
+    it('returns true when value is true', () => {
+      expect(isTrue(true)).toBe(true);
+      expect(isTrue('t')).toBe(true);
+      expect(isTrue('true')).toBe(true);
+      expect(isTrue('TRUE')).toBe(true);
+    });
+
+    it('returns false otherwise', () => {
+      expect(isTrue(null)).toBe(false);
+      expect(isTrue('f')).toBe(false);
+      expect(isTrue('false')).toBe(false);
+      expect(isTrue('FALSE')).toBe(false);
+    });
+  });
+});

--- a/src/modules/database.js
+++ b/src/modules/database.js
@@ -3,12 +3,12 @@ import SequelizeMock from '@mixnjuice/sequelize-mock';
 import Sequelize, { ValidationError, DatabaseError } from 'sequelize';
 
 import models from 'models';
-import configs from 'modules/config';
+import { database as config } from 'modules/config';
 import logging from 'modules/logging';
 import { isTestEnvironment } from 'modules/utils/test';
 
 const log = logging('database');
-const { host, port, password, username, database } = configs.database;
+const { host, port, password, username, database } = config;
 const validationProps = ['message', 'type', 'path', 'value'];
 
 const sequelize = isTestEnvironment()

--- a/src/modules/utils/index.js
+++ b/src/modules/utils/index.js
@@ -1,9 +1,8 @@
 import nanoid from 'nanoid';
 import { hash as create, compare } from 'bcrypt';
 
-import configs from 'modules/config';
+import { api as apiConfig, web as webConfig } from 'modules/config';
 
-const { api: apiConfig, web: webConfig } = configs;
 const {
   passwords: { saltRounds },
   tokens: { length: tokenLength }

--- a/src/modules/utils/utils.test.js
+++ b/src/modules/utils/utils.test.js
@@ -1,6 +1,6 @@
 import bcrypt from 'bcrypt';
 
-import configs from 'modules/config';
+import { web as webConfig } from 'modules/config';
 import {
   generateToken,
   buildWebUrl,
@@ -70,7 +70,7 @@ describe('utility methods', () => {
     });
 
     it('can construct https url', () => {
-      Object.defineProperties(configs.web, {
+      Object.defineProperties(webConfig, {
         hostname: {
           get: jest.fn().mockReturnValue('localhost')
         },

--- a/src/routes/register.js
+++ b/src/routes/register.js
@@ -4,13 +4,12 @@ import { body, query, validationResult } from 'express-validator';
 import Email from 'modules/email';
 import models, { handleError } from 'modules/database';
 import logging from 'modules/logging';
-import configs from 'modules/config';
+import { email as emailConfig, api as apiConfig } from 'modules/config';
 import { hashPassword, generateToken, buildWebUrl } from 'modules/utils';
 
 const router = Router();
 const log = logging('register');
 const { User, UserProfile } = models;
-const { email: emailConfig, api: apiConfig } = configs;
 const {
   tokens: { length: tokenLength }
 } = apiConfig;


### PR DESCRIPTION
By breaking out the config module into separate `export const` objects we can import only those that matter to a given file.

I added an `isTrue` helper for determining if a dotenv-sourced config key is a string representation of a boolean. I added tests for this util.