### PR TITLE
Add schema and models for flavor ingredient safety

### DIFF
--- a/schema/18.do.flavor-safety.sql
+++ b/schema/18.do.flavor-safety.sql
@@ -1,0 +1,61 @@
+create table ingredient_category (
+  id serial not null,
+  name varchar(50) not null,
+  ordinal int not null,
+  description text not null,
+
+  constraint pk_ingredient_category primary key (id),
+  constraint uk1_ingredient_category unique (name),
+  constraint uk2_ingredient_category unique (ordinal)
+);
+
+insert into ingredient_category (name, ordinal, description) values (1, 1, 'Flavors in this category should not be used.');
+insert into ingredient_category (name, ordinal, description) values ('Caution', 2, 'Flavors in this category should only be used sparingly.');
+insert into ingredient_category (name, ordinal, description) values (3, 3, 'Flavors in this category are being researched further.');
+
+create table ingredient (
+  id serial not null,
+  name varchar(100) not null,
+  cas_number varchar(50) not null,
+  ingredient_category_id int not null,
+  notes text default null,
+  created timestamp default now(),
+  updated timestamp default null,
+
+  constraint pk_ingredient primary key (id),
+  constraint uk1_ingredient unique (name),
+  constraint uk2_ingredient unique (cas_number),
+  constraint fk1_ingredient foreign key (ingredient_category_id) references ingredient_category (id)
+);
+
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Acetoin', '513-86-0', 3);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Acetyl Propionyl', '600-14-6', 3);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Acetyl Pyrazine', '22047-25-2', 3);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Caprylic Acid', '124-07-2', 3);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Caramel color', '8028-89-5', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Cocoa Butter', '8002-31-1', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Corn Syrup', '8029-43-4', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Diacetyl', '431-03-8', 3);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Fructose', '57-48-7', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Furfuryl alcohol', '98-0-0', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Molasses', '8052-35-5', 2);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Peppermint oil', '8006-90-4', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Polysorbate 80', '9005-65-6 ', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Rose oxide', '16409-43-1', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Sodium Chloride', '7647-14-5', 2);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Sucralose', '56038-13-2', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Triethyl Citrate', '77-93-0', 3);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Vitamin E Acetate', '58-95-7', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Vitamin E', '1406-18-4', 1);
+insert into ingredient (name, cas_number, ingredient_category_id) values ('Xylose', '58-86-6', 1);
+
+create table flavors_ingredients (
+  flavor_id bigint not null,
+  ingredient_id int not null,
+  created timestamp not null default now(),
+  updated timestamp not null,
+
+  constraint pk_flavors_ingredients primary key (flavor_id, ingredient_id),
+  constraint fk1_flavors_ingredients foreign key (flavor_id) references flavor (id),
+  constraint fk2_flavors_ingredients foreign key (ingredient_id) references ingredient (id)
+);

--- a/schema/18.undo.flavor-safety.sql
+++ b/schema/18.undo.flavor-safety.sql
@@ -1,0 +1,3 @@
+drop table flavors_ingredients;
+drop table ingredient;
+drop table ingredient_category;

--- a/src/models/flavor.js
+++ b/src/models/flavor.js
@@ -47,6 +47,12 @@ module.exports = (sequelize, DataTypes) => {
       foreignKey: 'flavorId',
       otherKey: 'recipeId'
     });
+    this.belongsToMany(models.Ingredient, {
+      as: 'Ingredients',
+      through: models.FlavorsIngredients,
+      foreignKey: 'flavorId',
+      otherKey: 'ingredientId'
+    });
     this.belongsToMany(models.User, {
       as: 'Owners',
       through: models.UsersFlavors,

--- a/src/models/flavorsIngredients.js
+++ b/src/models/flavorsIngredients.js
@@ -1,0 +1,51 @@
+module.exports = (sequelize, DataTypes) => {
+  const FlavorsIngredients = sequelize.define(
+    'FlavorsIngredients',
+    {
+      flavorId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Flavor,
+          key: 'id'
+        }
+      },
+      ingredientId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Ingredient,
+          key: 'id'
+        }
+      },
+      created: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW
+      },
+      updated: {
+        type: DataTypes.DATE,
+        allowNull: false
+      }
+    },
+    {
+      sequelize,
+      tableName: 'flavors_ingredients',
+      createdAt: 'created',
+      updatedAt: 'updated'
+    }
+  );
+
+  FlavorsIngredients.associate = function(models) {
+    this.belongsTo(models.Ingredient, {
+      foreignKey: 'ingredientId'
+    });
+    this.belongsTo(models.Flavor, {
+      foreignKey: 'flavorId'
+    });
+  };
+
+  return FlavorsIngredients;
+};

--- a/src/models/ingredient.js
+++ b/src/models/ingredient.js
@@ -1,0 +1,58 @@
+module.exports = (sequelize, DataTypes) => {
+  const Ingredient = sequelize.define(
+    'Ingredient',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true
+      },
+      casNumber: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true
+      },
+      ingredientCategoryId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        references: {
+          model: sequelize.IngredientCategory,
+          key: 'id'
+        }
+      },
+      notes: {
+        type: DataTypes.STRING,
+        allowNull: true
+      },
+      created: {
+        type: DataTypes.DATE,
+        allowNull: false,
+        defaultValue: DataTypes.NOW
+      },
+      updated: {
+        type: DataTypes.DATE,
+        allowNull: true
+      }
+    },
+    {
+      sequelize,
+      tableName: 'ingredient',
+      createdAt: 'created',
+      updatedAt: 'updated'
+    }
+  );
+
+  Ingredient.associate = function(models) {
+    this.hasOne(models.IngredientCategory, {
+      foreignKey: 'ingredientCategoryId'
+    });
+  };
+
+  return Ingredient;
+};

--- a/src/models/ingredientCategory.js
+++ b/src/models/ingredientCategory.js
@@ -1,0 +1,41 @@
+module.exports = (sequelize, DataTypes) => {
+  const IngredientCategory = sequelize.define(
+    'IngredientCategory',
+    {
+      id: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true
+      },
+      ordinal: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        unique: true
+      },
+      description: {
+        type: DataTypes.TEXT,
+        allowNull: false
+      }
+    },
+    {
+      sequelize,
+      tableName: 'ingredient_category',
+      createdAt: false,
+      updatedAt: false
+    }
+  );
+
+  IngredientCategory.associate = function(models) {
+    this.hasMany(models.Ingredient, {
+      foreignKey: 'ingredientCategoryId'
+    });
+  };
+
+  return IngredientCategory;
+};


### PR DESCRIPTION
This PR adds the schema migration and Sequelize models for flavor safety information.

I have an SDS parser which is currently outputting data in CSV format that can be re-engineered to store its data in these tables. It associates a single flavor to one or more ingredients which are indicated by CAS number in the safety data sheets. I have created three categories for the ingredients of interest - "avoid," "caution," and "research." They are ranked ordinally so that we can show only the most important warnings in some places but show the full list in others.

Work to enhance endpoints to return this data will be done in another PR.