### PR TITLE
Fix Mattermost notifier failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,14 +18,10 @@ jobs:
             docker-compose run --rm -v "$(pwd)"/coverage:/usr/src/flavor-api/coverage \
               api npm test
             bash <(curl -s https://codecov.io/bash) -f ./coverage/lcov.info
-  notify:
-    docker:
-      - image: byrnedo/alpine-curl:latest
-    steps:
       - mattermost-notify/notify_on_success:
-          webhook: '$MATTERMOST_WEBHOOK_API'
+        webhook: '$MATTERMOST_WEBHOOK_API'
       - mattermost-notify/notify_on_failure:
-          webhook: '$MATTERMOST_WEBHOOK_API'
+        webhook: '$MATTERMOST_WEBHOOK_API'
 
 workflows:
   version: 2
@@ -33,7 +29,3 @@ workflows:
     jobs:
       - build:
           context: builds
-      - notify:
-          context: webhooks
-          requires:
-            - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,6 @@ jobs:
     steps:
       - mattermost-notify/notify_on_success:
           webhook: '$MATTERMOST_WEBHOOK_API'
-    steps:
       - mattermost-notify/notify_on_failure:
           webhook: '$MATTERMOST_WEBHOOK_API'
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,9 +19,9 @@ jobs:
               api npm test
             bash <(curl -s https://codecov.io/bash) -f ./coverage/lcov.info
       - mattermost-notify/notify_on_success:
-        webhook: '$MATTERMOST_WEBHOOK_API'
+          webhook: '$MATTERMOST_WEBHOOK_API'
       - mattermost-notify/notify_on_failure:
-        webhook: '$MATTERMOST_WEBHOOK_API'
+          webhook: '$MATTERMOST_WEBHOOK_API'
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,15 +18,12 @@ jobs:
             docker-compose run --rm -v "$(pwd)"/coverage:/usr/src/flavor-api/coverage \
               api npm test
             bash <(curl -s https://codecov.io/bash) -f ./coverage/lcov.info
-  notify_success:
+  notify:
     docker:
       - image: byrnedo/alpine-curl:latest
     steps:
       - mattermost-notify/notify_on_success:
           webhook: '$MATTERMOST_WEBHOOK_API'
-  notify_failure:
-    docker:
-      - image: byrnedo/alpine-curl:latest
     steps:
       - mattermost-notify/notify_on_failure:
           webhook: '$MATTERMOST_WEBHOOK_API'
@@ -37,11 +34,7 @@ workflows:
     jobs:
       - build:
           context: builds
-      - notify_success:
-          context: webhooks
-          requires:
-            - build
-      - notify_failure:
+      - notify:
           context: webhooks
           requires:
             - build

--- a/src/routes/role.test.js
+++ b/src/routes/role.test.js
@@ -66,8 +66,4 @@ describe('role route resource', () => {
       request.delete('/15').expect(200, done);
     });
   });
-
-  it('fails', () => {
-    expect(true).toBe(false);
-  });
 });

--- a/src/routes/role.test.js
+++ b/src/routes/role.test.js
@@ -66,4 +66,8 @@ describe('role route resource', () => {
       request.delete('/15').expect(200, done);
     });
   });
+
+  it('fails', () => {
+    expect(true).toBe(false);
+  });
 });


### PR DESCRIPTION
This PR fixes notifications to Mattermost about build failures. Currently, the setup does not work because the `notify` job only triggers if the previous job was successful. To resolve this, inline the notify steps in the build job, where their `when: on_fail` and `when: on_success` will now work as expected.