### PR TITLE
Update vscode settings for plugin/vscode config schema changes

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
   "editor.formatOnSave": true,
   "eslint.enable": true,
   "eslint.run": "onSave",
-  "eslint.autoFixOnSave": true,
-  "prettier.eslintIntegration": true
+  "stylelint.enable": true,
+  "editor.codeActionsOnSave": {
+    "source.fixAll": true
+  }
 }


### PR DESCRIPTION
This PR mirrors [this one](https://github.com/mixnjuice/frontend/pull/49) from the frontend repo. It fixes application of eslint and stylelint on save and removes a deprecated setting.