### PR TITLE
Add user preferences migration scripts

### DIFF
--- a/schema/20.do.user-preferences.sql
+++ b/schema/20.do.user-preferences.sql
@@ -1,0 +1,23 @@
+create table preference (
+  id serial not null,
+  name varchar(100) not null,
+  key varchar(200) not null,
+  description text default null,
+  created timestamp not null default now(),
+
+  constraint pk_preference primary key (id),
+  constraint uk1_preference unique (name),
+  constraint uk2_preference unique (key)
+);
+
+create table users_preferences (
+  user_id bigint not null,
+  preference_id int not null,
+  value varchar(100) not null,
+  created timestamp not null default now(),
+  updated timestamp default null,
+
+  constraint pk_users_preferences primary key (user_id, preference_id),
+  constraint fk1_users_preferences foreign key (user_id) references "user" (id),
+  constraint fk2_users_preferences foreign key (preference_id) references preference (id)
+);

--- a/schema/20.undo.user-preferences.sql
+++ b/schema/20.undo.user-preferences.sql
@@ -1,0 +1,2 @@
+drop table users_preferences;
+drop table preference;


### PR DESCRIPTION
This PR adds a SQL migration that adds the following to the schema:

![keys](https://user-images.githubusercontent.com/266545/75001200-ba5b5d00-542e-11ea-8f8b-f8c93618609b.PNG)

This will allow us to store and associate preference data to users. Data is stored in the `value` field of `users_preferences` as a JSON string.