### PR TITLE
Fix anonymous permissions issue

### DIFF
--- a/schema/21.do.permissions.sql
+++ b/schema/21.do.permissions.sql
@@ -1,0 +1,93 @@
+create table permission_subject (
+  id serial not null,
+  name varchar(50) not null,
+
+  constraint pk_permission_subject primary key (id),
+  constraint uk1_permission_subject unique (name)
+);
+
+create table permission_action (
+  id serial not null,
+  name varchar(50) not null,
+
+  constraint pk_permission_action primary key (id),
+  constraint uk1_permission_action unique (name)
+);
+
+create table roles_permissions (
+  role_id int not null,
+  permission_subject_id int not null,
+  permission_action_id int not null,
+
+  constraint pk_roles_permissions primary key (role_id, permission_subject_id, permission_action_id),
+  constraint fk1_roles_permissions foreign key (role_id) references "role" (id),
+  constraint fk2_roles_permissions foreign key (permission_subject_id) references permission_subject (id),
+  constraint fk3_roles_permissions foreign key (permission_action_id) references permission_action (id)
+);
+
+insert into permission_subject (name) values
+  ('data'),
+  ('diluent'),
+  ('flavor'),
+  ('flavors'),
+  ('preparation'),
+  ('recipe'),
+  ('recipes'),
+  ('register'),
+  ('role'),
+  ('roles'),
+  ('stats'),
+  ('user');
+
+insert into permission_action (name) values
+  ('read'),
+  ('create'),
+  ('update'),
+  ('delete'),
+  ('manage');
+
+insert into "role" (name) values ('Guest');
+
+insert into roles_permissions
+  select r.id, ps.id, pa.id
+  from
+    "role" r
+    join permission_subject ps on ps.name in ('recipes', 'recipe', 'flavor', 'flavors', 'preparation', 'role', 'roles', 'user')
+    join permission_action pa on pa.name = 'read'
+  where r.name = 'Guest';
+
+insert into roles_permissions
+  select r.id, ps.id, pa.id
+  from
+    "role" r
+    join permission_subject ps on ps.name in ('recipes', 'recipe', 'flavor', 'flavors', 'preparation', 'role', 'roles', 'user')
+    join permission_action pa on pa.name = 'read'
+  where r.name = 'User';
+
+insert into roles_permissions
+  select r.id, ps.id, pa.id
+  from
+    "role" r
+    join permission_subject ps on ps.name in ('recipe', 'flavors', 'preparation')
+    join permission_action pa on pa.name in ('create', 'update', 'delete')
+  where r.name = 'User';
+
+insert into roles_permissions
+  select r.id, ps.id, pa.id
+  from
+    "role" r
+    cross join permission_subject ps
+    cross join permission_action pa
+  where r.name = 'Administrator';
+
+create view permission_summary as
+  select
+    r.id role_id,
+    r.name role_name,
+    ps.name permission_subject_name,
+    pa.name permission_action_name
+  from
+    roles_permissions rp
+    join "role" r on rp.role_id = r.id
+    join permission_subject ps on rp.permission_subject_id = ps.id
+    join permission_action pa on rp.permission_action_id = pa.id;

--- a/schema/21.undo.permissions.sql
+++ b/schema/21.undo.permissions.sql
@@ -1,0 +1,4 @@
+drop table roles_permissions;
+drop table permission_subject;
+drop table permission_action;
+drop view permission_summary;

--- a/src/models/permissionAction.js
+++ b/src/models/permissionAction.js
@@ -1,0 +1,34 @@
+module.exports = (sequelize, DataTypes) => {
+  const PermissionAction = sequelize.define(
+    'PermissionAction',
+    {
+      id: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true
+      }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'permission_action',
+      createdAt: false,
+      updatedAt: false
+    }
+  );
+
+  PermissionAction.associate = function(models) {
+    this.hasMany(models.RolesPermissions, {
+      as: 'RolesPermissions',
+      foreignKey: 'permissionActionId'
+    });
+  };
+
+  return PermissionAction;
+};

--- a/src/models/permissionSubject.js
+++ b/src/models/permissionSubject.js
@@ -1,0 +1,34 @@
+module.exports = (sequelize, DataTypes) => {
+  const PermissionSubject = sequelize.define(
+    'PermissionSubject',
+    {
+      id: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        autoIncrement: true
+      },
+      name: {
+        type: DataTypes.STRING,
+        allowNull: false,
+        unique: true
+      }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'permission_subject',
+      createdAt: false,
+      updatedAt: false
+    }
+  );
+
+  PermissionSubject.associate = function(models) {
+    this.hasMany(models.RolesPermissions, {
+      as: 'RolesPermissions',
+      foreignKey: 'permissionSubjectId'
+    });
+  };
+
+  return PermissionSubject;
+};

--- a/src/models/rolesPermissions.js
+++ b/src/models/rolesPermissions.js
@@ -1,0 +1,57 @@
+module.exports = (sequelize, DataTypes) => {
+  const RolesPermissions = sequelize.define(
+    'RolesPermissions',
+    {
+      roleId: {
+        type: DataTypes.BIGINT,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.Role,
+          key: 'id'
+        }
+      },
+      permissionSubjectId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.PermissionSubject,
+          key: 'id'
+        }
+      },
+      permissionActionId: {
+        type: DataTypes.INTEGER,
+        allowNull: false,
+        primaryKey: true,
+        references: {
+          model: sequelize.PermissionAction,
+          key: 'id'
+        }
+      }
+    },
+    {
+      sequelize,
+      underscored: true,
+      tableName: 'roles_permissions',
+      createdAt: false,
+      updatedAt: false
+    }
+  );
+
+  RolesPermissions.associate = function(models) {
+    this.belongsTo(models.Role, { foreignKey: 'roleId' });
+    this.hasOne(models.PermissionSubject, {
+      as: 'Subject',
+      foreignKey: 'id',
+      sourceKey: 'permissionSubjectId'
+    });
+    this.hasOne(models.PermissionAction, {
+      as: 'Action',
+      foreignKey: 'id',
+      sourceKey: 'permissionActionId'
+    });
+  };
+
+  return RolesPermissions;
+};

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -26,28 +26,32 @@ const authorize = async (token, done) => {
       );
     }
 
-    const result = await UserToken.findAll({
+    const userToken = await UserToken.findOne({
       where: {
         token,
         expires: {
           [Op.gt]: Date.now()
         }
-      },
-      include: [
-        {
-          model: User,
-          required: true
-        }
-      ]
+      }
     });
 
-    if (!Array.isArray(result) || result.length === 0) {
+    if (!userToken) {
       return done(
         new oauth2orize.TokenError('Authentication failed.', 'invalid_grant')
       );
     }
 
-    const [{ User: user }] = result;
+    const user = await User.findOne({
+      where: {
+        id: userToken.userId
+      },
+      include: [
+        {
+          model: Role,
+          as: 'Roles'
+        }
+      ]
+    });
 
     done(null, user, { scope: 'all' });
   } catch (error) {

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -156,46 +156,6 @@ export const authenticate = () => {
   ];
 };
 
-export const ensureRole = name => async (req, _, next) => {
-  if (isTestEnvironment() || !validateRoles) {
-    return next(null);
-  }
-
-  try {
-    const { user } = req;
-
-    if (!user) {
-      throw new Error('No user found!');
-    }
-
-    const id = parseInt(user.id, 10);
-
-    const role = await Role.findOne({
-      where: {
-        name
-      },
-      include: [
-        {
-          as: 'Users',
-          model: User,
-          required: true,
-          through: {
-            where: { userId: id }
-          }
-        }
-      ]
-    });
-
-    if (!role) {
-      throw new Error('User lacks required role!');
-    }
-
-    next(null);
-  } catch (error) {
-    next(error);
-  }
-};
-
 export const ensurePermission = (subject, action) => async (req, _, next) => {
   if (isTestEnvironment() || !validateRoles) {
     return next(null);

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -75,14 +75,14 @@ authServer.exchange(
         );
       }
 
-      const result = await User.findAll({
+      const user = await User.findOne({
         where: {
           emailAddress: username,
           activationCode: null
         }
       });
 
-      if (!Array.isArray(result) || result.length === 0) {
+      if (!user) {
         return done(
           new oauth2orize.AuthorizationError(
             'Authentication failed.',
@@ -91,7 +91,6 @@ authServer.exchange(
         );
       }
 
-      const [user] = result;
       const valid = await compareHashAndPassword(
         user.get('password'),
         password

--- a/src/modules/auth.js
+++ b/src/modules/auth.js
@@ -167,9 +167,6 @@ export const ensurePermission = (subject, action) => async (req, _, next) => {
     const { user } = req;
 
     if (user) {
-      // eslint-disable-next-line
-      console.dir(user);
-
       role = await Role.findOne({
         where: {
           id: user.Roles.map(r => r.id)

--- a/src/routes/data.js
+++ b/src/routes/data.js
@@ -22,6 +22,7 @@ const { DataSupplier, SchemaVersion } = models;
 router.get(
   '/supplier/:id',
   authenticate(),
+  ensurePermission('data', 'read'),
   [
     param('id')
       .isNumeric()
@@ -51,6 +52,7 @@ router.get(
 router.post(
   '/supplier',
   authenticate(),
+  ensurePermission('data', 'create'),
   [
     body('name')
       .isString()
@@ -77,6 +79,7 @@ router.post(
 router.put(
   '/supplier/:id',
   authenticate(),
+  ensurePermission('data', 'update'),
   [
     param('id')
       .isNumeric()
@@ -114,6 +117,7 @@ router.put(
 router.delete(
   '/supplier/:id',
   authenticate(),
+  ensurePermission('data', 'delete'),
   [
     param('id')
       .isNumeric()
@@ -137,13 +141,19 @@ router.delete(
 /**
  * GET Suppliers Stats
  */
-router.get('/suppliers/count', authenticate(), handleCount(DataSupplier));
+router.get(
+  '/suppliers/count',
+  authenticate(),
+  ensurePermission('data', 'read'),
+  handleCount(DataSupplier)
+);
 /**
  * GET Data Suppliers
  */
 router.get(
   '/suppliers',
   authenticate(),
+  ensurePermission('data', 'read'),
   [
     query('offset')
       .optional()

--- a/src/routes/data.js
+++ b/src/routes/data.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param, query } from 'express-validator';
 
-import { authenticate, ensureRole } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -167,7 +167,7 @@ router.get(
 router.get(
   '/version',
   authenticate(),
-  ensureRole('Administrator'),
+  ensurePermission('data', 'read'),
   handleFindAll(SchemaVersion)
 );
 

--- a/src/routes/data.js
+++ b/src/routes/data.js
@@ -68,6 +68,7 @@ router.post(
     return [{ name, code }];
   })
 );
+
 /**
  * PUT Update a Data Supplier
  * @param id int
@@ -110,6 +111,7 @@ router.put(
     ];
   })
 );
+
 /**
  * Delete a Data Supplier
  * @param id int
@@ -138,6 +140,7 @@ router.delete(
     ];
   })
 );
+
 /**
  * GET Suppliers Stats
  */
@@ -147,6 +150,7 @@ router.get(
   ensurePermission('data', 'read'),
   handleCount(DataSupplier)
 );
+
 /**
  * GET Data Suppliers
  */

--- a/src/routes/diluent.js
+++ b/src/routes/diluent.js
@@ -41,6 +41,7 @@ router.get(
     ];
   })
 );
+
 /**
  * POST Create a Diluent
  */
@@ -72,6 +73,7 @@ router.post(
     ];
   })
 );
+
 /**
  * PUT Update a Diluent
  * @param id int
@@ -118,6 +120,7 @@ router.put(
     ];
   })
 );
+
 /**
  * Delete Diluent
  * @param id int

--- a/src/routes/diluent.js
+++ b/src/routes/diluent.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -20,6 +20,7 @@ const { Diluent } = models;
 router.get(
   '/:id',
   authenticate(),
+  ensurePermission('diluent', 'read'),
   [
     param('id')
       .isNumeric()
@@ -46,6 +47,7 @@ router.get(
 router.post(
   '/',
   authenticate(),
+  ensurePermission('diluent', 'create'),
   [
     body('name')
       .isString()
@@ -81,6 +83,7 @@ router.post(
 router.put(
   '/:id',
   authenticate(),
+  ensurePermission('diluent', 'update'),
   [
     param('id')
       .isNumeric()
@@ -122,6 +125,7 @@ router.put(
 router.delete(
   '/:id',
   authenticate(),
+  ensurePermission('diluent', 'delete'),
   [
     param('id')
       .isNumeric()

--- a/src/routes/diluents.js
+++ b/src/routes/diluents.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { query } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import { handleFindAll, handleValidationErrors } from 'modules/utils/request';
@@ -18,6 +18,7 @@ const { Diluent } = models;
 router.get(
   '/',
   authenticate(),
+  ensurePermission('diluents', 'read'),
   [
     query('offset')
       .optional()
@@ -41,21 +42,26 @@ router.get(
 /**
  * GET Diluent Stats
  */
-router.get('/count', authenticate(), async (req, res) => {
-  log.info(`request for user stats`);
-  try {
-    const diluents = await Diluent.count();
-    // Results
-    const result = {
-      diluents
-    };
+router.get(
+  '/count',
+  authenticate(),
+  ensurePermission('diluent', 'read'),
+  async (req, res) => {
+    log.info(`request for user stats`);
+    try {
+      const diluents = await Diluent.count();
+      // Results
+      const result = {
+        diluents
+      };
 
-    res.type('application/json');
-    res.json(result);
-  } catch (error) {
-    log.error(error.message);
-    res.status(500).send(error.message);
+      res.type('application/json');
+      res.json(result);
+    } catch (error) {
+      log.error(error.message);
+      res.status(500).send(error.message);
+    }
   }
-});
+);
 
 export default router;

--- a/src/routes/flavor.js
+++ b/src/routes/flavor.js
@@ -288,6 +288,7 @@ router.post(
     ];
   })
 );
+
 /**
  * PUT Update a Flavor Identifier
  * @param flavorId int
@@ -334,6 +335,7 @@ router.put(
     ];
   })
 );
+
 /**
  * Delete Flavor Identifier
  * @param flavorId int

--- a/src/routes/flavor.js
+++ b/src/routes/flavor.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -21,6 +21,7 @@ const { DataSupplier, Flavor, FlavorIdentifier, Vendor } = models;
 router.get(
   '/:id',
   authenticate(),
+  ensurePermission('flavor', 'read'),
   [
     param('id')
       .isNumeric()
@@ -58,6 +59,7 @@ router.get(
 router.post(
   '/',
   authenticate(),
+  ensurePermission('flavor', 'create'),
   [
     body('vendorId')
       .isNumeric()
@@ -100,6 +102,7 @@ router.post(
 router.put(
   '/:id',
   authenticate(),
+  ensurePermission('flavor', 'update'),
   [
     param('id')
       .isNumeric()
@@ -148,6 +151,7 @@ router.put(
 router.delete(
   '/:id',
   authenticate(),
+  ensurePermission('flavor', 'delete'),
   [
     param('id')
       .isNumeric()
@@ -176,6 +180,7 @@ router.delete(
 router.get(
   '/:flavorId/identifiers',
   authenticate(),
+  ensurePermission('flavor', 'read'),
   [
     param('flavorId')
       .isNumeric()
@@ -209,6 +214,7 @@ router.get(
 router.get(
   '/:flavorId/identifier/:dataSupplierId',
   authenticate(),
+  ensurePermission('flavor', 'read'),
   [
     param('flavorId')
       .isNumeric()
@@ -252,6 +258,7 @@ router.get(
 router.post(
   '/:flavorId/identifier',
   authenticate(),
+  ensurePermission('flavor', 'create'),
   [
     param('flavorId')
       .isNumeric()
@@ -290,6 +297,8 @@ router.post(
 router.put(
   '/:flavorId/identifier/:dataSupplierId',
   authenticate(),
+  ensurePermission('flavor', 'update'),
+  ensurePermission('flavor', 'manage'),
   [
     param('flavorId')
       .isNumeric()
@@ -326,13 +335,15 @@ router.put(
   })
 );
 /**
- * Delete Diluent
+ * Delete Flavor Identifier
  * @param flavorId int
  * @param dataSupplierId int
  */
 router.delete(
   '/:flavorId/identifier/:dataSupplierId',
   authenticate(),
+  ensurePermission('flavor', 'delete'),
+  ensurePermission('flavor', 'manage'),
   [
     param('flavorId')
       .isNumeric()

--- a/src/routes/flavors.js
+++ b/src/routes/flavors.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { query } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -22,15 +22,15 @@ const { Flavor, Vendor } = models;
 router.get(
   '/',
   authenticate(),
-  [
-    query('offset')
+  ensurePermission('flavors', 'read')[
+    (query('offset')
       .optional()
       .isNumeric()
       .toInt(),
     query('limit')
       .optional()
       .isNumeric()
-      .toInt()
+      .toInt())
   ],
   handleValidationErrors(),
   handleFindAll(Flavor, req => {
@@ -54,6 +54,11 @@ router.get(
 /**
  * GET Flavor Stats
  */
-router.get('/count', authenticate(), handleCount(Flavor));
+router.get(
+  '/count',
+  authenticate(),
+  ensurePermission('flavors', 'read'),
+  handleCount(Flavor)
+);
 
 export default router;

--- a/src/routes/flavors.js
+++ b/src/routes/flavors.js
@@ -22,7 +22,8 @@ const { Flavor, Vendor } = models;
 router.get(
   '/',
   authenticate(),
-  ensurePermission('flavors', 'read')[
+  ensurePermission('flavors', 'read'),
+  [
     (query('offset')
       .optional()
       .isNumeric()

--- a/src/routes/preparation.js
+++ b/src/routes/preparation.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -27,6 +27,7 @@ const {
 router.get(
   '/:id',
   authenticate(),
+  ensurePermission('preparation', 'read'),
   [
     param('id')
       .isNumeric()
@@ -71,6 +72,7 @@ router.get(
     ];
   })
 );
+
 /**
  * POST Create a Preparation
  * @body recipeId int
@@ -82,6 +84,7 @@ router.get(
 router.post(
   '/',
   authenticate(),
+  ensurePermission('preparation', 'create'),
   [
     body('recipeId')
       .isNumeric()
@@ -158,6 +161,7 @@ router.post(
 router.put(
   '/:id',
   authenticate(),
+  ensurePermission('preparation', 'update'),
   [
     param('id')
       .isNumeric()
@@ -260,6 +264,7 @@ router.put(
 router.delete(
   '/:id',
   authenticate(),
+  ensurePermission('preparation', 'delete'),
   [
     param('id')
       .isNumeric()

--- a/src/routes/preparations.js
+++ b/src/routes/preparations.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { query } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import { handleFindAll, handleValidationErrors } from 'modules/utils/request';
@@ -18,6 +18,7 @@ const { Preparation } = models;
 router.get(
   '/',
   authenticate(),
+  ensurePermission('preparations', 'read'),
   [
     query('offset')
       .optional()

--- a/src/routes/recipe.js
+++ b/src/routes/recipe.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -29,6 +29,7 @@ const {
 router.get(
   '/:id',
   authenticate(),
+  ensurePermission('recipe', 'read'),
   [
     param('id')
       .isNumeric()
@@ -56,6 +57,7 @@ router.get(
     ]
   }))
 );
+
 /**
  * POST Create a Recipe and associations
  * @body userId int
@@ -67,6 +69,7 @@ router.get(
 router.post(
   '/',
   authenticate(),
+  ensurePermission('recipe', 'create'),
   [
     body('name')
       .isString()
@@ -177,6 +180,7 @@ router.post(
 router.put(
   '/:id',
   authenticate(),
+  ensurePermission('recipe', 'update'),
   [
     param('id')
       .isNumeric()
@@ -304,6 +308,7 @@ router.put(
     }
   }
 );
+
 /**
  * DELETE Recipe
  * @param id int
@@ -311,6 +316,7 @@ router.put(
 router.delete(
   '/:id',
   authenticate(),
+  ensurePermission('recipe', 'delete'),
   [
     param('id')
       .isNumeric()

--- a/src/routes/recipes.js
+++ b/src/routes/recipes.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { query } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import { handleFindAll, handleValidationErrors } from 'modules/utils/request';
@@ -18,6 +18,7 @@ const { Recipe } = models;
 router.get(
   '/',
   authenticate(),
+  ensurePermission('recipes', 'read'),
   [
     query('offset')
       .optional()

--- a/src/routes/role.js
+++ b/src/routes/role.js
@@ -20,6 +20,7 @@ const { Role } = models;
 router.get(
   '/:id(\\d+)',
   authenticate(),
+  ensurePermission('role', 'read'),
   [
     param('id')
       .isNumeric()
@@ -33,6 +34,7 @@ router.get(
     }
   }))
 );
+
 /**
  * PUT Update Role
  * @param roleId int
@@ -84,6 +86,7 @@ router.post(
     }
   ])
 );
+
 /**
  * DELETE Role
  * @param roleId int

--- a/src/routes/role.js
+++ b/src/routes/role.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 
-import { authenticate, ensureRole } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -41,7 +41,7 @@ router.get(
 router.put(
   '/:id(\\d+)',
   authenticate(),
-  ensureRole('Administrator'),
+  ensurePermission('role', 'update'),
   [
     param('id')
       .isNumeric()
@@ -75,7 +75,7 @@ router.put(
 router.post(
   '/',
   authenticate(),
-  ensureRole('Administrator'),
+  ensurePermission('role', 'create'),
   [body('name').isString()],
   handleValidationErrors(),
   handleModelOperation(Role, 'create', req => [
@@ -91,7 +91,7 @@ router.post(
 router.delete(
   '/:id(\\d+)',
   authenticate(),
-  ensureRole('Administrator'),
+  ensurePermission('role', 'delete'),
   [
     param('id')
       .isNumeric()

--- a/src/routes/roles.js
+++ b/src/routes/roles.js
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import { handleCount, handleFindAll } from 'modules/utils/request';
 
@@ -10,11 +10,21 @@ const { Role } = models;
 /**
  * GET Roles
  */
-router.get('/', authenticate(), handleFindAll(Role));
+router.get(
+  '/',
+  authenticate(),
+  ensurePermission('roles', 'read'),
+  handleFindAll(Role)
+);
 
 /**
  * GET Roles Stats
  */
-router.get('/count', authenticate(), handleCount(Role));
+router.get(
+  '/count',
+  authenticate(),
+  ensurePermission('roles', 'read'),
+  handleCount(Role)
+);
 
 export default router;

--- a/src/routes/stats.js
+++ b/src/routes/stats.js
@@ -1,5 +1,5 @@
 import { Router } from 'express';
-import { authenticate, ensureRole } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 
@@ -22,7 +22,7 @@ const {
 router.get(
   '/dashboard',
   authenticate(),
-  ensureRole('Administrator'),
+  ensurePermission('stats', 'read'),
   async (req, res) => {
     log.info(`request for dashboard stats`);
     try {

--- a/src/routes/user.js
+++ b/src/routes/user.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -30,6 +30,7 @@ const {
 router.get(
   '/:id(\\d+)',
   authenticate(),
+  ensurePermission('user', 'read'),
   [
     param('id')
       .isNumeric()
@@ -60,6 +61,7 @@ router.get(
 router.get(
   '/:userId(\\d+)/profile',
   authenticate(),
+  ensurePermission('user', 'read'),
   [
     param('userId')
       .isNumeric()
@@ -80,6 +82,7 @@ router.get(
     ];
   })
 );
+
 /**
  * PUT Update User's Profile
  * @param userId int
@@ -87,6 +90,7 @@ router.get(
 router.put(
   '/:userId(\\d+)/profile',
   authenticate(),
+  ensurePermission('user', 'update'),
   [
     param('userId')
       .isNumeric()
@@ -112,6 +116,7 @@ router.put(
     ];
   })
 );
+
 /**
  * GET User Recipes
  * @param userId int
@@ -119,6 +124,7 @@ router.put(
 router.get(
   '/:userId(\\d+)/recipes',
   authenticate(),
+  ensurePermission('user', 'read'),
   [
     param('userId')
       .isNumeric()
@@ -145,6 +151,7 @@ router.get(
 router.get(
   '/:userId(\\d+)/flavors',
   authenticate(),
+  ensurePermission('user', 'read'),
   [
     param('userId')
       .isNumeric()
@@ -175,6 +182,7 @@ router.get(
     };
   })
 );
+
 /**
  * GET A User Flavor
  * @param userId int
@@ -183,6 +191,7 @@ router.get(
 router.get(
   '/:userId(\\d+)/flavor/:flavorId(\\d+)',
   authenticate(),
+  ensurePermission('user', 'read'),
   [
     param('userId')
       .isNumeric()
@@ -218,6 +227,7 @@ router.get(
     };
   })
 );
+
 /**
  * POST Add Flavor to User's Flavor Stash
  * @param userId int - User ID
@@ -225,6 +235,7 @@ router.get(
 router.post(
   '/:userId(\\d+)/flavor',
   authenticate(),
+  ensurePermission('user', 'create'),
   [
     param('userId')
       .isNumeric()
@@ -248,6 +259,7 @@ router.post(
     ];
   })
 );
+
 /**
  * PUT Update User's Flavor Stash Entry
  * @param userId int
@@ -256,6 +268,7 @@ router.post(
 router.put(
   '/:userId(\\d+)/flavor/:flavorId(\\d+)',
   authenticate(),
+  ensurePermission('user', 'update'),
   [
     param('userId')
       .isNumeric()
@@ -295,6 +308,7 @@ router.put(
 router.delete(
   '/:userId(\\d+)/flavor/:flavorId(\\d+)',
   authenticate(),
+  ensurePermission('user', 'delete'),
   [
     param('userId')
       .isNumeric()
@@ -320,6 +334,7 @@ router.delete(
     ];
   })
 );
+
 /**
  * GET User Roles
  * @param userId int
@@ -327,6 +342,7 @@ router.delete(
 router.get(
   '/:userId(\\d+)/roles',
   authenticate(),
+  ensurePermission('user', 'read'),
   [
     param('userId')
       .isNumeric()
@@ -351,6 +367,7 @@ router.get(
     };
   })
 );
+
 /**
  * GET A User Role
  * @param userId int
@@ -359,6 +376,7 @@ router.get(
 router.get(
   '/:userId(\\d+)/role/:roleId(\\d+)',
   authenticate(),
+  ensurePermission('user', 'read'),
   [
     param('userId')
       .isNumeric()
@@ -390,6 +408,7 @@ router.get(
     ];
   })
 );
+
 /**
  * POST Add Role to User's Roles
  * @param userId int - User ID
@@ -399,6 +418,8 @@ router.get(
 router.post(
   '/:userId(\\d+)/role',
   authenticate(),
+  ensurePermission('user', 'update'),
+  ensurePermission('user', 'manage'),
   [
     param('userId')
       .isNumeric()
@@ -425,6 +446,7 @@ router.post(
     ];
   })
 );
+
 /**
  * PUT Update User's Role
  * @param userId int
@@ -434,6 +456,8 @@ router.post(
 router.put(
   '/:userId(\\d+)/role/:roleId(\\d+)',
   authenticate(),
+  ensurePermission('user', 'update'),
+  ensurePermission('user', 'manage'),
   [
     param('userId')
       .isNumeric()
@@ -473,6 +497,8 @@ router.put(
 router.delete(
   '/:userId(\\d+)/role/:roleId(\\d+)',
   authenticate(),
+  ensurePermission('user', 'delete'),
+  ensurePermission('user', 'manage'),
   [
     param('userId')
       .isNumeric()
@@ -499,15 +525,20 @@ router.delete(
   })
 );
 
-router.get('/current', authenticate(), async (req, res) => {
-  try {
-    res.type('application/json');
-    res.json(req.user);
-  } catch (error) {
-    log.error(error.message);
-    res.status(500).send(error.message);
+router.get(
+  '/current',
+  authenticate(),
+  ensurePermission('user', 'read'),
+  async (req, res) => {
+    try {
+      res.type('application/json');
+      res.json(req.user);
+    } catch (error) {
+      log.error(error.message);
+      res.status(500).send(error.message);
+    }
   }
-});
+);
 
 /**
  * GET User Info by Username
@@ -516,6 +547,7 @@ router.get('/current', authenticate(), async (req, res) => {
 router.get(
   '/name/:name',
   authenticate(),
+  ensurePermission('user', 'read'),
   [param('name').isString()],
   handleValidationErrors(),
   handleModelOperation(UserProfile, 'findOne', req => {

--- a/src/routes/users.js
+++ b/src/routes/users.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { query, param } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -22,6 +22,7 @@ const { Role, User, UserProfile, UsersRoles } = models;
 router.get(
   '/',
   authenticate(),
+  ensurePermission('users', 'read'),
   [
     query('offset')
       .optional()
@@ -50,6 +51,7 @@ router.get(
 router.get(
   '/accounts',
   authenticate(),
+  ensurePermission('users', 'read'),
   [
     query('offset')
       .optional()
@@ -78,6 +80,7 @@ router.get(
     };
   })
 );
+
 /**
  * GET Role Users
  * @param roleid int
@@ -85,6 +88,7 @@ router.get(
 router.get(
   '/role/:roleId(\\d+)',
   authenticate(),
+  ensurePermission('users', 'read'),
   [
     param('roleId')
       .isNumeric()
@@ -134,6 +138,11 @@ router.get(
 /**
  * GET User Stats
  */
-router.get('/count', authenticate(), handleCount(User));
+router.get(
+  '/count',
+  authenticate(),
+  ensurePermission('users', 'read'),
+  handleCount(User)
+);
 
 export default router;

--- a/src/routes/vendor.js
+++ b/src/routes/vendor.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { body, param } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import {
@@ -21,6 +21,7 @@ const { DataSupplier, Vendor, VendorIdentifier } = models;
 router.get(
   '/:id',
   authenticate(),
+  ensurePermission('vendor', 'read'),
   [
     param('id')
       .isNumeric()
@@ -41,6 +42,7 @@ router.get(
     ];
   })
 );
+
 /**
  * POST Create a Vendor
  * @body name string
@@ -50,6 +52,7 @@ router.get(
 router.post(
   '/',
   authenticate(),
+  ensurePermission('vendor', 'create'),
   [
     body('name')
       .isString()
@@ -78,6 +81,7 @@ router.post(
     ];
   })
 );
+
 /**
  * PUT Updates a Vendor
  * @param id int
@@ -89,6 +93,7 @@ router.post(
 router.put(
   '/:id',
   authenticate(),
+  ensurePermission('vendor', 'update'),
   [
     param('id')
       .isNumeric()
@@ -125,6 +130,7 @@ router.put(
     ];
   })
 );
+
 /**
  * DELETE Deletes a Vendor
  * @param id int
@@ -132,6 +138,7 @@ router.put(
 router.delete(
   '/:id',
   authenticate(),
+  ensurePermission('vendor', 'delete'),
   [
     param('id')
       .isNumeric()
@@ -147,6 +154,7 @@ router.delete(
     }
   ])
 );
+
 /**
  * GET Vendor Data Supplier Identifiers
  * @param id int
@@ -154,6 +162,7 @@ router.delete(
 router.get(
   '/:vendorId/identifiers',
   authenticate(),
+  ensurePermission('vendor', 'read'),
   [
     param('vendorId')
       .isNumeric()
@@ -179,6 +188,7 @@ router.get(
     };
   })
 );
+
 /**
  * GET Vendor Data Supplier Identifier
  * @param vendorId int
@@ -187,6 +197,7 @@ router.get(
 router.get(
   '/:vendorId/identifier/:dataSupplierId',
   authenticate(),
+  ensurePermission('vendor', 'read'),
   [
     param('vendorId')
       .isNumeric()
@@ -220,6 +231,7 @@ router.get(
     ];
   })
 );
+
 /**
  * POST Create a Vendor Identifier
  * @param id int
@@ -229,6 +241,7 @@ router.get(
 router.post(
   '/:vendorId/identifier',
   authenticate(),
+  ensurePermission('vendor', 'create'),
   [
     param('vendorId')
       .isNumeric()
@@ -258,6 +271,7 @@ router.post(
     ];
   })
 );
+
 /**
  * PUT Update a Vendor Identifier
  * @param vendorId int
@@ -267,6 +281,7 @@ router.post(
 router.put(
   '/:vendorId/identifier/:dataSupplierId',
   authenticate(),
+  ensurePermission('vendor', 'update'),
   [
     param('vendorId')
       .isNumeric()
@@ -302,14 +317,16 @@ router.put(
     ];
   })
 );
+
 /**
- * Delete Diluent
+ * Delete Vendor Identifier
  * @param vendorId int
  * @param dataSupplierId int
  */
 router.delete(
   '/:vendorId/identifier/:dataSupplierId',
   authenticate(),
+  ensurePermission('vendor', 'delete'),
   [
     param('vendorId')
       .isNumeric()

--- a/src/routes/vendors.js
+++ b/src/routes/vendors.js
@@ -1,7 +1,7 @@
 import { Router } from 'express';
 import { query } from 'express-validator';
 
-import { authenticate } from 'modules/auth';
+import { authenticate, ensurePermission } from 'modules/auth';
 import models from 'modules/database';
 import loggers from 'modules/logging';
 import { handleFindAll, handleValidationErrors } from 'modules/utils/request';
@@ -18,6 +18,7 @@ const { Vendor } = models;
 router.get(
   '/',
   authenticate(),
+  ensurePermission('vendors', 'read'),
   [
     query('offset')
       .optional()
@@ -37,24 +38,30 @@ router.get(
     return { limit, offset };
   })
 );
+
 /**
  * GET Vendor Stats
  */
-router.get('/count', authenticate(), async (req, res) => {
-  log.info(`request for vendor stats`);
-  try {
-    const vendors = await Vendor.count();
-    // Results
-    const result = {
-      vendors
-    };
+router.get(
+  '/count',
+  authenticate(),
+  ensurePermission('vendors', 'read'),
+  async (req, res) => {
+    log.info(`request for vendor stats`);
+    try {
+      const vendors = await Vendor.count();
+      // Results
+      const result = {
+        vendors
+      };
 
-    res.type('application/json');
-    res.json(result);
-  } catch (error) {
-    log.error(error.message);
-    res.status(500).send(error.message);
+      res.type('application/json');
+      res.json(result);
+    } catch (error) {
+      log.error(error.message);
+      res.status(500).send(error.message);
+    }
   }
-});
+);
 
 export default router;


### PR DESCRIPTION
Currently, there is an issue (identified by @daviddyess ) where anonymous users will not be able to fetch required API routes for the public pages (e.g. recipe view).

To resolve this, I have made the following changes:

 * [Create](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/permissions-overhaul?expand=1#diff-137acb549024bd9d802e64d32a5b2146R1) three new tables in the schema - permission_subject, permission_action, and roles_permissions. Subjects and actions are defined per the [CASL](https://www.npmjs.com/package/@casl/ability) spec.
 * [Insert](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/permissions-overhaul?expand=1#diff-137acb549024bd9d802e64d32a5b2146R28) starter permission_subject and permission_action values and add a Guest role
 * [Add](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/permissions-overhaul?expand=1#diff-bf2c1f1e3a48b267123290949b386462) Sequelize models for these tables
 * [Use](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/permissions-overhaul?expand=1#diff-0c9614a084d6e4ba1ccd77842a359e7eR37) findOne instead of findAll where it makes more sense
 * [Include](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/permissions-overhaul?expand=1#diff-0c9614a084d6e4ba1ccd77842a359e7eR56) user roles in the data model that gets stored as `req.user`
 * [Replace](https://github.com/mixnjuice/api/compare/master...ayan4m1:feature/permissions-overhaul?expand=1#diff-0c9614a084d6e4ba1ccd77842a359e7eR159) ensureRole with ensurePermission

ensurePermission takes two arguments, a string subject and a string action. This allows it to match on a more granular level than ensureRole could.