### PR TITLE
Add `npm run build` to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Now, in a shell:
 
 ```sh
 npm install
+npm run build
 cp .env.default .env
 ```
 


### PR DESCRIPTION
This PR addresses a small gap in the API documentation, adding in the missing "build" step that transpiles files to `lib/`